### PR TITLE
Added sitemap for udata-gouvfr specific URLs

### DIFF
--- a/udata_gouvfr/tests.py
+++ b/udata_gouvfr/tests.py
@@ -223,3 +223,24 @@ class DataconnexionsTest(FrontTestCase):
             VisibleReuseFactory(tags=[DATACONNEXIONS_TAG, tag])
         response = self.client.get(url_for('gouvfr.dataconnexions'))
         self.assert200(response)
+
+
+class SitemapTest(FrontTestCase):
+    settings = GouvFrSettings
+
+    def test_urls_within_sitemap(self):
+        '''It should add gouvfr pages to sitemap.'''
+        response = self.get('sitemap.xml')
+        self.assert200(response)
+
+        urls = [
+            url_for('gouvfr.credits_redirect', _external=True),
+            url_for('gouvfr.terms_redirect', _external=True),
+            url_for('gouvfr.redevances_redirect', _external=True),
+            url_for('gouvfr.faq_redirect', _external=True),
+        ]
+        for section in ('citizen', 'producer', 'reuser', 'developer'):
+            urls.append(url_for('gouvfr.faq_redirect', section='citizen', _external=True))
+
+        for url in urls:
+            self.assertIn('<loc>{url}</loc>'.format(url=url), response.data)

--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -6,6 +6,7 @@ from flask import url_for, redirect
 from udata import theme
 from udata.models import Reuse
 from udata.i18n import I18nBlueprint
+from udata.sitemap import sitemap
 
 
 blueprint = I18nBlueprint('gouvfr', __name__, template_folder='templates', static_folder='static')
@@ -85,3 +86,14 @@ def credits():
 @blueprint.route('/terms/')
 def terms():
     return theme.render('terms.html')
+
+
+@sitemap.register_generator
+def gouvfr_sitemap_urls():
+    yield 'gouvfr.faq_redirect', {}, None, 'weekly', 1
+    for section in ('citizen', 'producer', 'reuser', 'developer'):
+        yield 'gouvfr.faq_redirect', {'section': section}, None, 'weekly', 0.7
+    yield 'gouvfr.dataconnexions_redirect', {}, None, 'monthly', 0.4
+    yield 'gouvfr.redevances_redirect', {}, None, 'yearly', 0.4
+    yield 'gouvfr.terms_redirect', {}, None, 'monthly', 0.2
+    yield 'gouvfr.credits_redirect', {}, None, 'monthly', 0.2


### PR DESCRIPTION
Export udata-gouvfr specifics URLs to the sitemap.

Connects to etalab/udata#46