### PR TITLE
Use static_url_path to avoid static conflict on blueprint

### DIFF
--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -10,8 +10,10 @@ from udata.i18n import I18nBlueprint
 from udata.sitemap import sitemap
 
 
-blueprint = I18nBlueprint(
-    'gouvfr', __name__, template_folder='templates', static_folder='static')
+blueprint = I18nBlueprint('gouvfr', __name__,
+                          template_folder='templates',
+                          static_folder='static',
+                          static_url_path='/static/gouvfr')
 
 
 @blueprint.route('/dataset/<dataset>/')


### PR DESCRIPTION
This pull request add a `static_url_path` parameter to the blueprint to avoid url resolution conflicts with the main app.