### PR TITLE
Remove white spaces before punctuation, refs #153

### DIFF
--- a/udata_gouvfr/theme/templates/subnav-large.html
+++ b/udata_gouvfr/theme/templates/subnav-large.html
@@ -40,10 +40,10 @@
             <h2>{{ _('Share, improve and reuse public data') }}</h2>
             <div class="collapse subnav-collapse">
                 <a class="btn btn-primary btn-big btn-transparent icon-left"
-                        title="{{ _('Contribute !') }}"
+                        title="{{ _('Contribute!') }}"
                         data-toggle="modal" data-target="#publish-action-modal">
                     <span class="glyphicon glyphicon-plus"></span>
-                    {{ _('Contribute !' )}}
+                    {{ _('Contribute!' )}}
                 </a>
             </div>
         </div>

--- a/udata_gouvfr/theme/templates/subnav-small.html
+++ b/udata_gouvfr/theme/templates/subnav-small.html
@@ -39,10 +39,10 @@
             {# Publish call to action #}
             <div class="col-sm-4 col-md-3 col-lg-3 col-xs-12 collapse subnav-collapse">
                 <a class="btn btn-primary btn-transparent btn-block btn-md icon-left"
-                        title="{{ _('Contribute !') }}"
+                        title="{{ _('Contribute!') }}"
                         data-toggle="modal" data-target="#publish-action-modal">
                     <span class="glyphicon glyphicon-plus"></span>
-                    {{ _('Contribute !') }}
+                    {{ _('Contribute!') }}
                 </a>
             </div>
         </div>

--- a/udata_gouvfr/theme/templates/topic/subnav.html
+++ b/udata_gouvfr/theme/templates/topic/subnav.html
@@ -47,10 +47,10 @@
                     {{ _('Read more') }}
                 </a> #}
                 <a class="btn btn-primary btn-big btn-transparent icon-left"
-                        title="{{ _('Contribute !') }}"
+                        title="{{ _('Contribute!') }}"
                         data-toggle="modal" data-target="#publish-action-modal">
                     <span class="glyphicon glyphicon-plus"></span>
-                    {{ _('Contribute !' )}}
+                    {{ _('Contribute!' )}}
                 </a>
             {# </div> #}
         </div>


### PR DESCRIPTION
That's the correct way in English and given that we use the label for integration tests I want those to be perennial.