### PR TITLE
display organization.accronym or title in the header dropdown menu. fix #227

### DIFF
--- a/udata_gouvfr/theme/templates/header.html
+++ b/udata_gouvfr/theme/templates/header.html
@@ -81,7 +81,7 @@
                             <a href="{{ url_for('organizations.show', org=org) }}">
                                 <img src="{{ org.logo(20)|placeholder('organization') }}"
                                     width="20" height="20"/>
-                                {{ org }}
+                                {{ org.acronym or org.name }}
                             </a>
                         </li>
                         {% endfor %}

--- a/udata_gouvfr/theme/templates/header.html
+++ b/udata_gouvfr/theme/templates/header.html
@@ -81,7 +81,7 @@
                             <a href="{{ url_for('organizations.show', org=org) }}">
                                 <img src="{{ org.logo(20)|placeholder('organization') }}"
                                     width="20" height="20"/>
-                                {{ org.name }}
+                                {{ org }}
                             </a>
                         </li>
                         {% endfor %}


### PR DESCRIPTION
Fix for https://github.com/etalab/udata/issues/227.

See https://github.com/etalab/udata/compare/etalab:master...vinyll:227-use-organization-acronym for changes to apply.