### PR TITLE
Improve the logo, fix etalab/udata#360

### DIFF
--- a/theme/img/logo-colophon.md
+++ b/theme/img/logo-colophon.md
@@ -2,5 +2,4 @@
 
 The logo is a combination of the official SVG
 https://fr.wikipedia.org/wiki/Fichier:Logo_de_la_R%C3%A9publique_fran%C3%A7aise_%281999%29.svg
-and the Fira Sans Regular font by Mozilla
-http://mozilla.github.io/Fira/
+and the Century Gothic Std font (bold).

--- a/theme/img/logo-header.svg
+++ b/theme/img/logo-header.svg
@@ -10,7 +10,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="473.31473"
+   width="512.5965"
    height="99.499977"
    id="svg2"
    inkscape:version="0.91 r13725"
@@ -44,7 +44,7 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:zoom="1.4142136"
+     inkscape:zoom="0.7071068"
      inkscape:cx="252.72388"
      inkscape:cy="32.785304"
      inkscape:window-x="45"
@@ -86,7 +86,7 @@
   </g>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:14.94835186px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#373c42;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
+     style="font-style:normal;font-weight:normal;font-size:14.94835186px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#373c42;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      x="207.34169"
      y="64.129326"
      id="text3345"
@@ -96,5 +96,7 @@
        id="tspan3347"
        x="207.34169"
        y="64.129326"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:46.71360016px;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';fill:#373c42;fill-opacity:1;">data.gouv.fr</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:46.71360016px;font-family:'Century Gothic Std';-inkscape-font-specification:'Century Gothic Std Bold';fill:#373c42;fill-opacity:1">data.gouv<tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:56.25px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic'"
+   id="tspan3356">.fr</tspan></tspan></text>
 </svg>


### PR DESCRIPTION
Original:

<img width="528" alt="capture d ecran 2016-02-18 a 09 41 31" src="https://cloud.githubusercontent.com/assets/3556/13142081/1f99c27c-d63b-11e5-8ebc-8d50ba31158e.png">

Using the Fira Sans font:

<img width="511" alt="capture d ecran 2016-02-18 a 09 41 42" src="https://cloud.githubusercontent.com/assets/3556/13142084/22d91e06-d63b-11e5-9f37-02ca26cd8071.png">

Back to the Century Gothic Std (bold):

<img width="497" alt="capture d ecran 2016-02-18 a 12 23 08" src="https://cloud.githubusercontent.com/assets/3556/13142106/4e8dc826-d63b-11e5-97b3-373c9da9d6ee.png">

With the end like [gouvernement.fr](http://www.gouvernement.fr/) but without the capslock:

<img width="502" alt="capture d ecran 2016-02-18 a 12 35 52" src="https://cloud.githubusercontent.com/assets/3556/13142252/34c663e8-d63c-11e5-9977-f56d593cfb2e.png">

With the HTML tag like the [forum](https://forum.etalab.gouv.fr/):

<img width="502" alt="capture d ecran 2016-02-18 a 12 24 44" src="https://cloud.githubusercontent.com/assets/3556/13142151/8c2799a0-d63b-11e5-9a33-65e4fb7ddd56.png">
