### PR TITLE
Display last forum topics on home page

### DIFF
--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -553,6 +553,37 @@ ul.search-results {
     }
 }
 
+section.forum-topics {
+    a {
+        color: black;
+    }
+
+    table td {
+        padding: 0;
+
+        a {
+            display: block;
+            width: 100%;
+            height: 100%;
+            padding: 8px;
+
+            &:hover, &:active, &:focus {
+                text-decoration: none;
+            }
+
+        }
+
+        .label {
+            font-size: 70%;
+            padding: .1em .4em;
+        }
+
+        .topic-title {
+            font-weight: bold;
+        }
+    }
+}
+
 
 .cover-communaute {
     width: 140px;

--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -558,7 +558,7 @@ section.forum-topics {
         color: black;
     }
 
-    table td {
+    table td, table th {
         padding: 0;
 
         a {
@@ -576,10 +576,6 @@ section.forum-topics {
         .label {
             font-size: 70%;
             padding: .1em .4em;
-        }
-
-        .topic-title {
-            font-weight: bold;
         }
     }
 }

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -198,6 +198,59 @@
       </div>
 </section>
 {% endif %}
+{% if forum_topics %}
+<section class="default forum-topics">
+      <div class="container forum-topics-container">
+            <div class="row">
+                <div class="col-xs-12">
+                    <h3><a href="{{ config.DISCOURSE_URL }}">{{ _('Latest forum discussions') }}</a></h3>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-xs-12">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>{{ _('Title') }}</th>
+                                <th>{{ _('Users') }}</th>
+                                <th>{{ _('Created at') }}</th>
+                                <th class="text-center">{{ _('Replies') }}</th>
+                                <th class="text-center">{{ _('Views') }}</th>
+                                <th class="text-center">{{ _('Likes') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for topic in forum_topics %}
+                            <tr>
+                                <td>
+                                    <a href="{{topic.url}}">
+                                        <span class="topic-title">{{topic.title}}</span>
+                                        <span class="label label-primary">{{topic.category}}</span>
+                                    </a>
+                                </td>
+                                <td>
+                                    <a href="{{topic.url}}">
+                                        {% for poster in topic.posters %}
+                                        <img class="img-circle" width="25" height="25"
+                                        src="{{ poster.avatar_url.format(size=50) }}"
+                                        alt="{{ poster.name }}" />
+                                        {% endfor %}
+                                    </a>
+                                </td>
+                                <td><a href="{{topic.url}}">{{topic.created_at|datetimeformat}}</a></td>
+                                <td class="text-center"><a href="{{topic.url}}">{{topic.replies}}</a></td>
+                                <td class="text-center"><a href="{{topic.url}}">{{topic.views}}</a></td>
+                                <td class="text-center"><a href="{{topic.url}}">{{topic.likes}}</a></td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+      </div>
+</section>
+{% endif %}
 {# End blog section #}
 {% endcache %}
 {% endblock %}

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -223,25 +223,25 @@
                         <tbody>
                             {% for topic in forum_topics %}
                             <tr>
-                                <td>
-                                    <a href="{{topic.url}}">
-                                        <span class="topic-title">{{topic.title}}</span>
-                                        <span class="label label-primary">{{topic.category}}</span>
+                                <th>
+                                    <a href="{{ topic.url }}">
+                                        {{ topic.title }}
+                                        <span class="label label-primary">{{ topic.category }}</span>
                                     </a>
-                                </td>
+                                </th>
                                 <td>
-                                    <a href="{{topic.url}}">
+                                    <a href="{{ topic.url }}">
                                         {% for poster in topic.posters %}
                                         <img class="img-circle" width="25" height="25"
-                                        src="{{ poster.avatar_url.format(size=50) }}"
-                                        alt="{{ poster.name }}" />
+                                            src="{{ poster.avatar_url.format(size=50) }}"
+                                            alt="{{ poster.name }}" />
                                         {% endfor %}
                                     </a>
                                 </td>
-                                <td><a href="{{topic.url}}">{{topic.created_at|datetimeformat}}</a></td>
-                                <td class="text-center"><a href="{{topic.url}}">{{topic.replies}}</a></td>
-                                <td class="text-center"><a href="{{topic.url}}">{{topic.views}}</a></td>
-                                <td class="text-center"><a href="{{topic.url}}">{{topic.likes}}</a></td>
+                                <td><a href="{{ topic.url }}">{{ topic.created_at|datetimeformat }}</a></td>
+                                <td class="text-center"><a href="{{ topic.url }}">{{ topic.replies }}</a></td>
+                                <td class="text-center"><a href="{{ topic.url }}">{{ topic.views }}</a></td>
+                                <td class="text-center"><a href="{{ topic.url }}">{{ topic.likes }}</a></td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/udata_gouvfr/theme/theme.py
+++ b/udata_gouvfr/theme/theme.py
@@ -99,13 +99,12 @@ def get_blog_post(url, lang):
 
 @cache.cached(50)
 def get_discourse_posts():
-    topics = []
     base_url = current_app.config.get('DISCOURSE_URL')
     category_id = current_app.config.get('DISCOURSE_CATEGORY_ID')
     listing = current_app.config.get('DISCOURSE_LISTING_TYPE', 'latest')
     limit = current_app.config.get('DISCOURSE_LISTING_LIMIT', 5)
     if not base_url:
-        return topics
+        return
 
     # Fetch site wide configuration (including all categories labels)
     site_url = '{url}/site.json'.format(url=base_url)
@@ -113,7 +112,7 @@ def get_discourse_posts():
         response = requests.get(site_url)
     except requests.exceptions.RequestException:
         log.exception('Unable to fetch discourses categories')
-        return topics
+        return
     data = response.json()
 
     # Resolve categories names
@@ -134,7 +133,7 @@ def get_discourse_posts():
         response = requests.get(url)
     except requests.exceptions.RequestException:
         log.exception('Unable to fetch discourses topics')
-        return topics
+        return
     data = response.json()
 
     # Resolve posters avatars
@@ -147,6 +146,7 @@ def get_discourse_posts():
         }
 
     # Parse topics
+    topics = []
     topic_pattern = '{url}/t/{slug}/{id}'
     for topic in data['topic_list']['topics']:
         last_posted_at = topic['last_posted_at']


### PR DESCRIPTION
This PR display latest forum topics on home page (include demo feedback)
This is optionnal and use the following settings:

* `DISCOURSE_URL` *(required)*: the remote Discourse instance base URL
* `DISCOURSE_CATEGORY_ID`: an optionnal category ID to limit topics from
* `DISCOURSE_LISTING_TYPE`: the listing type, one of `latest`, `top` or `new`. Default to `latest`
* `DISCOURSE_LISTING_LIMIT`: the amount of topics to fetch and display.

![screenshot-www data dev 2016-03-02 19-37-22](https://cloud.githubusercontent.com/assets/15725/13470846/3d59331a-e0ae-11e5-9e2e-f68c9ef7ece3.png)
