### PR TITLE
Use site author instead of hardcoded text

### DIFF
--- a/udata_gouvfr/theme/templates/dataset/display.html
+++ b/udata_gouvfr/theme/templates/dataset/display.html
@@ -1,3 +1,3 @@
 {% extends 'dataset/display.html' %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_TITLE ) %}
+{% set community_subtitle = _('Explore with %(certifier)s', certifier=config.SITE_TITLE ) %}

--- a/udata_gouvfr/theme/templates/dataset/display.html
+++ b/udata_gouvfr/theme/templates/dataset/display.html
@@ -1,3 +1,3 @@
 {% extends 'dataset/display.html' %}
 
-{% set community_subtitle = _('Explore with Datagouv') %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR %}

--- a/udata_gouvfr/theme/templates/dataset/display.html
+++ b/udata_gouvfr/theme/templates/dataset/display.html
@@ -1,3 +1,3 @@
 {% extends 'dataset/display.html' %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR ) %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_TITLE ) %}

--- a/udata_gouvfr/theme/templates/dataset/display.html
+++ b/udata_gouvfr/theme/templates/dataset/display.html
@@ -1,3 +1,3 @@
 {% extends 'dataset/display.html' %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR ) %}

--- a/udata_gouvfr/theme/templates/reuse/display.html
+++ b/udata_gouvfr/theme/templates/reuse/display.html
@@ -1,6 +1,6 @@
 {% extends "reuse/display.html" %}
 
-{% set community_subtitle = _('Explore with Datagouv') %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR %}
 
 {% block subnav %}
     {% include theme('subnav-community.html') with context %}

--- a/udata_gouvfr/theme/templates/reuse/display.html
+++ b/udata_gouvfr/theme/templates/reuse/display.html
@@ -1,6 +1,6 @@
 {% extends "reuse/display.html" %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR ) %}
 
 {% block subnav %}
     {% include theme('subnav-community.html') with context %}

--- a/udata_gouvfr/theme/templates/reuse/display.html
+++ b/udata_gouvfr/theme/templates/reuse/display.html
@@ -1,6 +1,6 @@
 {% extends "reuse/display.html" %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_TITLE ) %}
+{% set community_subtitle = _('Explore with %(certifier)s', certifier=config.SITE_TITLE ) %}
 
 {% block subnav %}
     {% include theme('subnav-community.html') with context %}

--- a/udata_gouvfr/theme/templates/reuse/display.html
+++ b/udata_gouvfr/theme/templates/reuse/display.html
@@ -1,6 +1,6 @@
 {% extends "reuse/display.html" %}
 
-{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_AUTHOR ) %}
+{% set community_subtitle = _('Explore with %(certifier)', certifier=config.SITE_TITLE ) %}
 
 {% block subnav %}
     {% include theme('subnav-community.html') with context %}


### PR DESCRIPTION
Replaces hard-coded references to Datagouv with SITE_AUTHOR from the config.

This complements https://github.com/etalab/udata/pull/443

In practice, this is only used in the header of the community contributions, for the dataset and reuse pages.