### PR TITLE
Map MAAF Harvester frequencies to  Dublin Core ones

### DIFF
--- a/udata_gouvfr/harvesters/maaf.py
+++ b/udata_gouvfr/harvesters/maaf.py
@@ -39,14 +39,14 @@ ZONES = {
 
 FREQUENCIES = {
     'ponctuelle': 'punctual',
-    'temps réel': 'realtime',
+    'temps réel': 'continuous',
     'quotidienne': 'daily',
     'hebdomadaire': 'weekly',
-    'bimensuelle': 'fortnighly',
+    'bimensuelle': 'semimonthly',
     'mensuelle': 'monthly',
     'bimestrielle': 'bimonthly',
     'trimestrielle': 'quarterly',
-    'semestrielle': 'biannual',
+    'semestrielle': 'semiannual',
     'annuelle': 'annual',
     'triennale': 'triennial',
     'quinquennale': 'quinquennial',


### PR DESCRIPTION
This PR make use of Dublin Core frequencies in MAAF Harvester (see opendatateam/udata#631)