### PR TITLE
No more git udata repository download, use published packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,6 @@ dependencies:
     # Install jq required by circleci-requirements.sh (explanation in file)
     - sudo apt-get update && sudo apt-get install jq
   override:
-    - pip install -U pip
     - ./circleci-requirements.sh
     - nvm use && nvm alias default $(nvm current) && npm install
 test:

--- a/circleci-requirements.sh
+++ b/circleci-requirements.sh
@@ -13,4 +13,11 @@ elif [[ $CIRCLE_TAG ]]; then
 else
   BASE_BRANCH=$CIRCLE_BRANCH
 fi
-pip install -U -e . -r circleci.$BASE_BRANCH.pip
+if [[ $BASE_BRANCH == "dev" ]]; then
+    # Test against last published  pre version
+    pip install -U --pre udata[test]
+else
+    # Test against last published stable version
+    pip install -U udata[test]
+fi
+pip install -e . invoke

--- a/circleci.dev.pip
+++ b/circleci.dev.pip
@@ -1,3 +1,0 @@
---pre udata
--r https://raw.githubusercontent.com/opendatateam/udata/dev/requirements/test.pip
-invoke>=0.13

--- a/circleci.master.pip
+++ b/circleci.master.pip
@@ -1,3 +1,0 @@
-udata
--r https://raw.githubusercontent.com/opendatateam/udata/master/requirements/test.pip
-invoke>=0.13


### PR DESCRIPTION
Change a little bit the build:
- use published packaged only (was already started)
- same requirements for dev/master but use pre version of udata on dev
- no more requirement files
