### PR TITLE
Split bootstrap style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#164](https://github.com/etalab/udata-gouvfr/pull/164)
 - Adjust the dataset reuses title overflow for proper display
   [#172](https://github.com/etalab/udata-gouvfr/pull/172)
+- Drop glyphicons and remove some useles classes
+  [#175](https://github.com/etalab/udata-gouvfr/pull/175)
 
 ## 1.0.5 (2017-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   [#164](https://github.com/etalab/udata-gouvfr/pull/164)
 - Adjust the dataset reuses title overflow for proper display
   [#172](https://github.com/etalab/udata-gouvfr/pull/172)
-- Drop glyphicons and remove some useles classes
-  [#175](https://github.com/etalab/udata-gouvfr/pull/175)
+- Drop glyphicons, remove some useless classes and upgrade to bootstrap 3.3.7
+  [#177](https://github.com/etalab/udata-gouvfr/pull/177)
 
 ## 1.0.5 (2017-04-06)
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "webpack": "^1.12.11"
   },
   "dependencies": {
-    "bootstrap": "^3.3.5"
+    "bootstrap": "^3.3.7"
   }
 }

--- a/theme/less/gouvfr-dataset.less
+++ b/theme/less/gouvfr-dataset.less
@@ -166,13 +166,17 @@ body.dataset-display {
 
         .infos-list {
             li {
-                margin-bottom: 3px;
+                margin-bottom: 5px;
             }
             a {
                 font-weight: bold;
                 color: #565656;
+
+                &:hover:first-of-type {
+                    text-decoration: none;
+                }
             }
-            .glyphicon, .fa {
+            .fa {
                 color: #aeaeae;
             }
         }

--- a/theme/less/gouvfr-post.less
+++ b/theme/less/gouvfr-post.less
@@ -73,18 +73,12 @@ body.post-display {
             position: relative;
             display: flex;
             justify-content: center;
+            flex-direction: column;
             align-items: center;
 
             img {
                 background-color: white;
                 border: 1px solid @gray-lighter;
-            }
-
-            .credit-link {
-                color: white;
-
-                .pull-right();
-                margin-top: 5px;
             }
         }
     }

--- a/theme/less/gouvfr-reuse.less
+++ b/theme/less/gouvfr-reuse.less
@@ -77,7 +77,7 @@ body.reuse-display {
         background-color: #28343d;
 
         .btn-transparent {
-            .fa, .glyphicon {
+            .fa {
                 color: #28343d !important;
             }
         }

--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -97,7 +97,7 @@ section.footer {
 
 
     .social {
-        .fa, .glyphicon {
+        .fa {
             opacity: 0.3;
             margin-right: 6px;
             font-size: 2.5em;
@@ -113,7 +113,7 @@ section.footer {
             color: @gray-lighter;
             text-decoration: none;
 
-            .fa, .glyphicon {
+            .fa {
                 opacity: 1;
                 color: white;
             }

--- a/theme/less/gouvfr/buttons.less
+++ b/theme/less/gouvfr/buttons.less
@@ -39,6 +39,10 @@
 .btn-big {
     font-size: 13px;
     padding: 12px 16px;
+
+    &.btn-left {
+        .fa-left-square(42px);
+    }
 }
 
 .btn-sm {
@@ -84,8 +88,8 @@
     text-align: left;
     text-transform: none;
     padding: 6px 10px;
-    .glyphicon {
-        padding-top: 1px;
+    .fa {
+        padding-top: 2px;
         color: rgba(255, 255, 255, 0.5) !important;
     }
     &:hover {
@@ -97,25 +101,6 @@
         background: rgba(0, 0, 0, 0.1) !important;
         color: white;
         border: 1px solid rgba(0, 0, 0, 0.1);
-    }
-}
-
-.icon-left {
-
-    .glyph-left-square(32px);
-
-    &.btn-sm {
-        .glyph-left-square(30px);
-    }
-
-    &.btn-punch {
-        @media (min-width: @screen-xs) {
-            .glyph-left-square(37px);
-        }
-    }
-
-    &.btn-big {
-        .glyph-left-square(42px);
     }
 }
 
@@ -137,22 +122,18 @@
 
 .btn-transparent {
     @base-color: fadeout(white, 50%);
-    // background-color: @base-color;
     background-color: rgba(255, 255, 255, 0.3);
 
-    .glyphicon {
+    .fa {
         color: @bg-dark !important;
         background-color: white !important;
-
     }
 
     &:hover {
         color: white;
         background-color: rgba(255, 255, 255, 0.55);
-        // color: @bg-dark;
-        // background-color: fadein(@base-color, 20%);
 
-        .glyphicon {
+        .fa {
             color: white !important;
             background-color: @bg-dark !important;
         }

--- a/theme/less/gouvfr/mixins.less
+++ b/theme/less/gouvfr/mixins.less
@@ -45,13 +45,13 @@
     white-space: nowrap;
 }
 
-.glyph-left-square(@size) {
+.fa-left-square(@size) {
     @base-padding: 15px;
     padding-left: @size + @base-padding;
     padding-right: @base-padding;
     position: relative;
 
-    .glyphicon {
+    .fa {
         color: rgba(255, 255, 255, 0.5);
         background-color: rgba(0, 0, 0, 0.15);
         position: absolute;

--- a/theme/less/gouvfr/navbars.less
+++ b/theme/less/gouvfr/navbars.less
@@ -241,7 +241,7 @@
     }
 
 
-    .glyphicon {
+    .fa {
         color: #bfbfbf;
     }
 

--- a/udata_gouvfr/templates/c3.html
+++ b/udata_gouvfr/templates/c3.html
@@ -134,7 +134,7 @@
         <div class="clearfix text-center">
             <a class="btn btn-default"
                 href="{{ url_for('datasets.list', badge=badge) }}">
-                <span class="glyphicon glyphicon-list"></span>
+                <span class="fa fa-fw fa-list"></span>
                 {{ _('See the %(nb)s datasets', nb=datasets|length) }}
             </a>
         </div>

--- a/udata_gouvfr/templates/nec_mergitur.html
+++ b/udata_gouvfr/templates/nec_mergitur.html
@@ -76,7 +76,7 @@
         <div class="clearfix text-center">
             <a class="btn btn-default"
                 href="{{ url_for('datasets.list', badge=badge) }}">
-                <span class="glyphicon glyphicon-list"></span>
+                <span class="fa fa-fw fa-list"></span>
                 {{ _('See the %(nb)s datasets', nb=datasets|length) }}
             </a>
         </div>

--- a/udata_gouvfr/templates/openfield16.html
+++ b/udata_gouvfr/templates/openfield16.html
@@ -186,7 +186,7 @@
         <div class="clearfix text-center">
             <a class="btn btn-default"
                 href="{{ url_for('datasets.list', badge=badge) }}">
-                <span class="glyphicon glyphicon-list"></span>
+                <span class="fa fa-fw fa-list"></span>
                 {{ _('See the %(nb)s datasets', nb=datasets|length) }}
             </a>
         </div>

--- a/udata_gouvfr/theme/templates/header.html
+++ b/udata_gouvfr/theme/templates/header.html
@@ -106,7 +106,7 @@
                 <li>
                     <a title="{{ _('Sign In / Register') }}"
                         href="{{ url_for('security.login', next=request.url) }}">
-                        <span class="glyphicon glyphicon-log-in"></span>
+                        <span class="fa fa-fw fa-sign-in"></span>
                         {{ _('Sign In / Register') }}
                     </a>
                 </li>

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -32,13 +32,6 @@
                                     {{ reuse.title }}
                                     </a>
                                 </h4>
-                                {# {% if user.sysadmin %}
-                                <a class="btn btn-xs btn-warning unfeature" v-tooltip href
-                                    data-api="{{ url_for('youckan/reuse', reuse.id, 'unfeature') }}"
-                                    title="{{ _('Unmark as featured') }}">
-                                    <span class="glyphicon glyphicon-trash"></span>
-                                </a>
-                                {% endif %} #}
                             </div>
                         </div>
                         {% endfor %}
@@ -151,7 +144,7 @@
                         <div class="clearfix"></div>
                         <p class="text-center">
                             <a href="{{ url_for('datasets.list', **kwargs) }}" class="btn btn-default btn-more">
-                                <span class="glyphicon glyphicon-list" ></span>
+                                <span class="fa fa-fw fa-list" ></span>
                                 {{ _('See more') }}
                             </a>
                         </p>

--- a/udata_gouvfr/theme/templates/subnav-large.html
+++ b/udata_gouvfr/theme/templates/subnav-large.html
@@ -32,10 +32,10 @@
         <div class="call-to-action col-sm-7 col-md-8 col-lg-7 col-xs-12">
             <h2>{{ _('Share, improve and reuse public data') }}</h2>
             <div class="collapse subnav-collapse">
-                <a class="btn btn-primary btn-big btn-transparent icon-left"
+                <a class="btn btn-primary btn-big btn-transparent btn-left"
                         title="{{ _('Contribute!') }}"
                         data-toggle="modal" data-target="#publish-action-modal">
-                    <span class="glyphicon glyphicon-plus"></span>
+                    <span class="fa fa-plus"></span>
                     {{ _('Contribute!' )}}
                 </a>
             </div>

--- a/udata_gouvfr/theme/templates/subnav-small.html
+++ b/udata_gouvfr/theme/templates/subnav-small.html
@@ -24,7 +24,7 @@
             <div class="form-group col-sm-4 col-md-3 col-lg-3 col-xs-12">
                 <button class="dropdown-toggle btn-block btn-light" data-toggle="dropdown">
                     {{ _('Topics') }}
-                    <span class="glyphicon glyphicon-chevron-down pull-right hidden-sm"></span>
+                    <span class="fa fa-chevron-down pull-right hidden-sm"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="topics">
                     {% for topic in g.featured_topics %}
@@ -40,10 +40,10 @@
 
             {# Publish call to action #}
             <div class="col-sm-4 col-md-3 col-lg-3 col-xs-12 collapse subnav-collapse">
-                <a class="btn btn-primary btn-transparent btn-block btn-md icon-left"
+                <a class="btn btn-primary btn-transparent btn-block btn-md btn-left"
                         title="{{ _('Contribute!') }}"
                         data-toggle="modal" data-target="#publish-action-modal">
-                    <span class="glyphicon glyphicon-plus"></span>
+                    <span class="fa fa-plus"></span>
                     {{ _('Contribute!') }}
                 </a>
             </div>

--- a/udata_gouvfr/theme/templates/topic/subnav.html
+++ b/udata_gouvfr/theme/templates/topic/subnav.html
@@ -33,24 +33,13 @@
         </div>
 
         <div class="topic-toolbar btn-toolbar pull-right">
-            {# <div class="btn-group btn-group-sm more"> #}
-                {# <a href class="btn btn-default"
-                    data-toggle="modal" data-target="#topic-modal">
-                    {{ _('Read more') }}
-                </a> #}
-                <a class="btn btn-primary btn-big btn-transparent icon-left"
-                        title="{{ _('Contribute!') }}"
-                        data-toggle="modal" data-target="#publish-action-modal">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    {{ _('Contribute!' )}}
-                </a>
-            {# </div> #}
+            <a class="btn btn-primary btn-big btn-transparent btn-left"
+                    title="{{ _('Contribute!') }}"
+                    data-toggle="modal" data-target="#publish-action-modal">
+                <span class="fa fa-plus"></span>
+                {{ _('Contribute!' )}}
+            </a>
         </div>
-        {# <div class="call-to-action">
-            <div class="collapse subnav-collapse btn-container">
-            </div>
-        </div> #}
-
+        
     </div>
-
 </nav>


### PR DESCRIPTION
This PR is the gouvfr theme part of opendatateam/udata#869:
- upgrade to latest bootstrap 3.3.7
- drop some unused classes (`.icon-left`...)
- remove all Glyphicons reference and use only font-awesome