### PR TITLE
Fix translations collision on contact

### DIFF
--- a/udata_gouvfr/theme/templates/footer.html
+++ b/udata_gouvfr/theme/templates/footer.html
@@ -45,7 +45,7 @@
             </section>
 
             <section class="col-xs-6 col-sm-3 col-md-4 col-lg-4 social">
-                <h5>{{ _('Contact') }}</h5>
+                <h5>{{ _('Contacts') }}</h5>
                 <a href="https://twitter.com/datagouvfr" title="Twitter">
                     <span class="fa fa-twitter-square"></span>
                 </a>


### PR DESCRIPTION
This PR is workaround for a translation collision on "contact":
- the action "contact" translates to "Contacter"
- the contact section in this theme footer translates to "Contact".

As Jinja does not support `pgettext` (see pallets/jinja#441), there is no proper way to differenciate the 2 string.
So this workaround switch the footer section name to the plural form "Contacts" (it is a list of contact point)