### PR TITLE
correction installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ You can execute `udata-gouvfr` specific tasks from the `udata-gouvfr` directory.
 
 ```shell
 cd udata-gouvfr
-inv assets_build
+npm install
+inv assets-build
 ```
 
 You can list available development commands with:


### PR DESCRIPTION
need to do a npm install in udata-gouvfr before launching inv assets-build and not inv assets_build.
took it from udata documentation http://udata.readthedocs.io/en/stable/development-environment/, not sure about the impact