### PR TITLE
Remove the common dropdown style behavior

### DIFF
--- a/.circleci/requirements.pip
+++ b/.circleci/requirements.pip
@@ -1,3 +1,3 @@
 invoke==0.21.0
 readme-renderer==17.2
-udata[test]>=1.2.0.dev
+udata[test]>=1.2.5.dev4759

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Export CSS dropdown behavior to `udata` [#234](https://github.com/etalab/udata-gouvfr/pull/234)
 
 ## 1.2.1 (2017-12-06)
 

--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -540,10 +540,6 @@ section.forum-topics {
 
 @media (min-width: @screen-md-min) {
     .navbar .links {
-        .dropdown-hover:hover .dropdown-menu {
-            display: block;
-        }
-
         .dropdown-menu {
             border: none;
             .box-shadow(5px 5px 5px rgba(0, 0, 0, 0.176));

--- a/theme/less/gouvfr/navbars.less
+++ b/theme/less/gouvfr/navbars.less
@@ -624,10 +624,6 @@
             border-top: none;
             border-radius: 0;
         }
-
-        &.open .dropdown-menu {
-            display: inline;
-        }
     }
 }
 


### PR DESCRIPTION
This PR moves CSS dropdown behaviors to `udata` core (see opendatateam/udata#1297)