### PR TITLE
Remove extra padding on community resources and discussions

### DIFF
--- a/theme/less/gouvfr/community.less
+++ b/theme/less/gouvfr/community.less
@@ -41,8 +41,6 @@
     }
 
     .resources-list {
-        padding-left: 8px;
-
         @color-sides: #e9e9e9;
         @color-body: #fafafa;
 


### PR DESCRIPTION
This PR remove the extra padding on community resources.

## Before

![screenshot-www data gouv fr-2018-01-24-12-57-58-931](https://user-images.githubusercontent.com/15725/35331094-72b55096-0106-11e8-94df-f4f5b10f0945.png)
![screenshot-www data gouv fr-2018-01-24-12-58-19-950](https://user-images.githubusercontent.com/15725/35331095-73bb05b2-0106-11e8-9c30-4abbb2dade84.png)

## After

![screenshot-data xps-2018-01-24-12-59-01-415](https://user-images.githubusercontent.com/15725/35331125-79de5d04-0106-11e8-851f-8fe554d56f7f.png)
![screenshot-data xps-2018-01-24-12-59-26-517](https://user-images.githubusercontent.com/15725/35331132-7d18a57e-0106-11e8-8bbc-aa20edef9260.png)
