### PR TITLE
Migrate test to pure pytest and plugin usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ node_modules
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
+.pytest_cache
 .tox
 cover
 nosetests.xml

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,2 @@
-udata>=1.3.0.dev
+udata>=1.3.0.dev6282
 feedparser==5.2.1

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,5 @@
-httpretty==0.8.14
 mock==2.0.0
 pytest==3.4.0
 pytest-flask==0.10.0
 pytest-sugar==0.9.1
+requests-mock==1.4.0

--- a/udata_gouvfr/tests.py
+++ b/udata_gouvfr/tests.py
@@ -4,7 +4,7 @@ import cgi
 import json
 import sys
 
-import httpretty
+import pytest
 import requests
 
 from flask import url_for
@@ -19,14 +19,11 @@ from udata.core.spatial.factories import SpatialCoverageFactory
 from udata.frontend.markdown import md
 from udata.models import Badge, PUBLIC_SERVICE
 from udata.settings import Testing
-from udata.tests import TestCase, DBTestMixin
-from udata.tests.api import APITestCase
-from udata.tests.frontend import FrontTestCase
-from udata.tests.test_sitemap import SitemapTestCase
 from udata.tests.features.territories.test_territories_process import (
     create_geozones_fixtures
 )
 from udata.utils import faker
+from udata.tests.helpers import assert200, assert404, assert_redirects
 
 from .models import (
     DATACONNEXIONS_5_CANDIDATE, DATACONNEXIONS_6_CANDIDATE,
@@ -48,114 +45,102 @@ class UnloadTheme(object):
     As setuptools entrypoint is loaded only once,
     this mixin ensure theme is reloaded.
     '''
-    def tearDown(self):
-        super(UnloadTheme, self).tearDown()
+    @pytest.fixture(autouse=True)
+    def unload_theme(self):
+        yield
         del sys.modules['udata_gouvfr.theme']
 
 
-class GouvFrThemeTest(UnloadTheme, FrontTestCase):
+class GouvFrThemeTest(UnloadTheme):
     '''Ensure themed views render'''
     settings = GouvFrSettings
+    modules = []
 
-    def test_render_home(self):
+    def test_render_home(self, autoindex, client):
         '''It should render the home page'''
-        with self.autoindex():
+        with autoindex:
             for i in range(3):
                 org = OrganizationFactory()
                 DatasetFactory(organization=org)
                 ReuseFactory(organization=org)
 
-        response = self.get(url_for('site.home'))
-        self.assert200(response)
+        response = client.get(url_for('site.home'))
+        assert200(response)
 
-    def test_render_home_no_data(self):
+    def test_render_home_no_data(self, client):
         '''It should render the home page without data'''
-        response = self.get(url_for('site.home'))
-        self.assert200(response)
+        response = client.get(url_for('site.home'))
+        assert200(response)
 
-    def test_render_search(self):
+    def test_render_search(self, autoindex, client):
         '''It should render the search page'''
-        with self.autoindex():
+        with autoindex:
             for i in range(3):
                 org = OrganizationFactory()
                 DatasetFactory(organization=org)
                 ReuseFactory(organization=org)
 
-        response = self.get(url_for('search.index'))
-        self.assert200(response)
+        response = client.get(url_for('search.index'))
+        assert200(response)
 
-    def test_render_search_no_data(self):
+    def test_render_search_no_data(self, autoindex, client):
         '''It should render the search page without data'''
-        self.init_search()
-        response = self.get(url_for('search.index'))
-        self.assert200(response)
+        response = client.get(url_for('search.index'))
+        assert200(response)
 
-    def test_render_metrics(self):
-        '''It should render the search page'''
+    def test_render_metrics(self, client):
+        '''It should render the dashboard page'''
         for i in range(3):
             org = OrganizationFactory()
             DatasetFactory(organization=org)
             ReuseFactory(organization=org)
-        response = self.get(url_for('site.dashboard'))
-        self.assert200(response)
+        response = client.get(url_for('site.dashboard'))
+        assert200(response)
 
-    def test_render_metrics_no_data(self):
-        '''It should render the search page without data'''
-        response = self.get(url_for('site.dashboard'))
-        self.assert200(response)
+    def test_render_metrics_no_data(self, client):
+        '''It should render the dashboard page without data'''
+        response = client.get(url_for('site.dashboard'))
+        assert200(response)
 
-    def test_render_dataset_page(self):
+    def test_render_dataset_page(self, client):
         '''It should render the dataset page'''
         org = OrganizationFactory()
         dataset = DatasetFactory(organization=org)
         ReuseFactory(organization=org, datasets=[dataset])
 
-        response = self.get(url_for('datasets.show', dataset=dataset))
-        self.assert200(response)
+        response = client.get(url_for('datasets.show', dataset=dataset))
+        assert200(response)
 
-    def test_render_organization_page(self):
+    def test_render_organization_page(self, client):
         '''It should render the organization page'''
         org = OrganizationFactory()
         datasets = [DatasetFactory(organization=org) for _ in range(3)]
         for dataset in datasets:
             ReuseFactory(organization=org, datasets=[dataset])
 
-        response = self.get(url_for('organizations.show', org=org))
-        self.assert200(response)
+        response = client.get(url_for('organizations.show', org=org))
+        assert200(response)
 
-    def test_render_reuse_page(self):
+    def test_render_reuse_page(self, client):
         '''It should render the reuse page'''
         org = OrganizationFactory()
         dataset = DatasetFactory(organization=org)
         reuse = ReuseFactory(organization=org, datasets=[dataset])
 
-        response = self.get(url_for('reuses.show', reuse=reuse))
-        self.assert200(response)
+        response = client.get(url_for('reuses.show', reuse=reuse))
+        assert200(response)
 
 
 WP_ATOM_URL = 'http://somewhere.test/feed.atom'
 
 
-def exception_factory(exception):
-    def callback(request, uri, headers):
-        raise exception
-    return callback
-
-
-class GouvFrWithBlogSettings(Testing):
-    TEST_WITH_THEME = True
-    TEST_WITH_PLUGINS = True
-    PLUGINS = ['gouvfr']
-    THEME = 'gouvfr'
-    WP_ATOM_URL = WP_ATOM_URL
-
-
-class GouvFrHomeBlogTest(UnloadTheme, FrontTestCase):
+@pytest.mark.options(WP_ATOM_URL=WP_ATOM_URL)
+class GouvFrHomeBlogTest(UnloadTheme):
     '''Ensure home page render with blog'''
-    settings = GouvFrWithBlogSettings
+    settings = GouvFrSettings
+    modules = []
 
-    @httpretty.activate
-    def test_render_home_with_blog(self):
+    def test_render_home_with_blog(self, rmock, client):
         '''It should render the home page with the latest blog article'''
         post_url = faker.uri()
         feed = AtomFeed('Some blog', feed_url=WP_ATOM_URL)
@@ -166,34 +151,28 @@ class GouvFrHomeBlogTest(UnloadTheme, FrontTestCase):
                  url=post_url,
                  updated=faker.date_time(),
                  published=faker.date_time())
-        httpretty.register_uri(httpretty.GET, WP_ATOM_URL,
-                               body=feed.to_string(),
-                               content_type='application/atom+xml')
-        response = self.get(url_for('site.home'))
-        self.assert200(response)
-        self.assertIn('Some post', response.data.decode('utf8'))
-        self.assertIn(post_url, response.data.decode('utf8'))
+        rmock.get(WP_ATOM_URL, text=feed.to_string(),
+                  headers={'Content-Type': 'application/atom+xml'})
+        response = client.get(url_for('site.home'))
+        assert200(response)
+        assert 'Some post' in response.data.decode('utf8')
+        assert post_url in response.data.decode('utf8')
 
-    @httpretty.activate
-    def test_render_home_if_blog_timeout(self):
+    def test_render_home_if_blog_timeout(self, rmock, client):
         '''It should render the home page when blog time out'''
-        exception = requests.Timeout('Blog timed out')
-        httpretty.register_uri(httpretty.GET, WP_ATOM_URL,
-                               body=exception_factory(exception))
-        response = self.get(url_for('site.home'))
-        self.assert200(response)
+        rmock.get(WP_ATOM_URL, exc=requests.Timeout('Blog timed out'))
+        response = client.get(url_for('site.home'))
+        assert200(response)
 
-    @httpretty.activate
-    def test_render_home_if_blog_error(self):
+    def test_render_home_if_blog_error(self, rmock, client):
         '''It should render the home page when blog is not available'''
-        exception = requests.ConnectionError('Connection error')
-        httpretty.register_uri(httpretty.GET, WP_ATOM_URL,
-                               body=exception_factory(exception))
-        response = self.get(url_for('site.home'))
-        self.assert200(response)
+        rmock.get(WP_ATOM_URL, exc=requests.ConnectionError('Error'))
+        response = client.get(url_for('site.home'))
+        assert200(response)
 
 
-class GouvFrMetricsTest(DBTestMixin, TestCase):
+@pytest.mark.usefixtures('clean_db')
+class GouvFrMetricsTest:
     '''Check metrics'''
     settings = GouvFrSettings
 
@@ -205,134 +184,133 @@ class GouvFrMetricsTest(DBTestMixin, TestCase):
         for _ in range(3):
             OrganizationFactory()
 
-        self.assertEqual(PublicServicesMetric().get_value(),
-                         len(public_services))
+        assert PublicServicesMetric().get_value() == len(public_services)
 
 
-class LegacyUrlsTest(FrontTestCase):
+@pytest.mark.options(DEFAULT_LANGUAGE='en')
+class LegacyUrlsTest:
     settings = GouvFrSettings
+    modules = []
 
-    def create_app(self):
-        app = super(LegacyUrlsTest, self).create_app()
-        app.config['DEFAULT_LANGUAGE'] = 'en'
-        return app
-
-    def test_redirect_datasets(self):
+    def test_redirect_datasets(self, client):
         dataset = DatasetFactory()
-        response = self.client.get('/en/dataset/%s/' % dataset.slug)
-        self.assertRedirects(
-            response, url_for('datasets.show', dataset=dataset))
+        response = client.get('/en/dataset/%s/' % dataset.slug)
+        assert_redirects(response, url_for('datasets.show', dataset=dataset))
 
-    def test_redirect_datasets_not_found(self):
-        response = self.client.get('/en/DataSet/wtf')
-        self.assert404(response)
+    def test_redirect_datasets_not_found(self, client):
+        response = client.get('/en/DataSet/wtf')
+        assert404(response)
 
-    def test_redirect_organizations(self):
+    def test_redirect_organizations(self, client):
         org = OrganizationFactory()
-        response = self.client.get('/en/organization/%s/' % org.slug)
-        self.assertRedirects(response, url_for('organizations.show', org=org))
+        response = client.get('/en/organization/%s/' % org.slug)
+        assert_redirects(response, url_for('organizations.show', org=org))
 
-    def test_redirect_organization_list(self):
-        response = self.client.get('/en/organization/')
-        self.assertRedirects(response, url_for('organizations.list'))
+    def test_redirect_organization_list(self, client):
+        response = client.get('/en/organization/')
+        assert_redirects(response, url_for('organizations.list'))
 
-    def test_redirect_topics(self):
-        response = self.client.get('/en/group/societe/')
-        self.assertRedirects(
-            response, url_for('topics.display', topic='societe'))
+    def test_redirect_topics(self, client):
+        response = client.get('/en/group/societe/')
+        assert_redirects(response, url_for('topics.display', topic='societe'))
 
 
-class SpecificUrlsTest(FrontTestCase):
+class SpecificUrlsTest:
     settings = GouvFrSettings
+    modules = []
 
-    def test_redevances(self):
-        response = self.client.get(url_for('gouvfr.redevances'))
-        self.assert200(response)
+    def test_redevances(self, client):
+        response = client.get(url_for('gouvfr.redevances'))
+        assert200(response)
 
-    def test_terms(self):
-        response = self.client.get(url_for('site.terms'))
-        self.assert200(response)
+    def test_terms(self, client):
+        response = client.get(url_for('site.terms'))
+        assert200(response)
 
-    def test_credits(self):
-        response = self.client.get(url_for('gouvfr.credits'))
-        self.assert200(response)
+    def test_credits(self, client):
+        response = client.get(url_for('gouvfr.credits'))
+        assert200(response)
 
-    def test_licences(self):
-        response = self.client.get(url_for('gouvfr.licences'))
-        self.assert200(response)
+    def test_licences(self, client):
+        response = client.get(url_for('gouvfr.licences'))
+        assert200(response)
 
 
-class DataconnexionsTest(FrontTestCase):
+class DataconnexionsTest:
     settings = GouvFrSettings
+    modules = []
 
-    def test_redirect_to_last_dataconnexions(self):
-        response = self.client.get(url_for('gouvfr.dataconnexions'))
-        self.assertRedirects(response, url_for('gouvfr.dataconnexions6'))
+    def test_redirect_to_last_dataconnexions(self, client):
+        response = client.get(url_for('gouvfr.dataconnexions'))
+        assert_redirects(response, url_for('gouvfr.dataconnexions6'))
 
-    def test_render_dataconnexions_5_without_data(self):
-        response = self.client.get(url_for('gouvfr.dataconnexions5'))
-        self.assert200(response)
+    def test_render_dataconnexions_5_without_data(self, client):
+        response = client.get(url_for('gouvfr.dataconnexions5'))
+        assert200(response)
 
-    def test_render_dataconnexions_5_with_data(self):
+    def test_render_dataconnexions_5_with_data(self, client):
         for tag, label, description in DATACONNEXIONS_5_CATEGORIES:
             badge = Badge(kind=DATACONNEXIONS_5_CANDIDATE)
             VisibleReuseFactory(tags=[tag], badges=[badge])
-        response = self.client.get(url_for('gouvfr.dataconnexions5'))
-        self.assert200(response)
+        response = client.get(url_for('gouvfr.dataconnexions5'))
+        assert200(response)
 
-    def test_render_dataconnexions_6_without_data(self):
-        response = self.client.get(url_for('gouvfr.dataconnexions6'))
-        self.assert200(response)
+    def test_render_dataconnexions_6_without_data(self, client):
+        response = client.get(url_for('gouvfr.dataconnexions6'))
+        assert200(response)
 
-    def test_render_dataconnexions_6_with_data(self):
+    def test_render_dataconnexions_6_with_data(self, client):
         # Use tags until we are sure all reuse are correctly labeled
         for tag, label, description in DATACONNEXIONS_6_CATEGORIES:
             badge = Badge(kind=DATACONNEXIONS_6_CANDIDATE)
             VisibleReuseFactory(tags=['dataconnexions-6', tag], badges=[badge])
-        response = self.client.get(url_for('gouvfr.dataconnexions6'))
-        self.assert200(response)
+        response = client.get(url_for('gouvfr.dataconnexions6'))
+        assert200(response)
 
 
-class C3Test(FrontTestCase):
+class C3Test:
     settings = GouvFrSettings
+    modules = []
 
-    def test_redirect_c3(self):
-        response = self.client.get(url_for('gouvfr.c3'))
-        self.assertRedirects(response, '/en/climate-change-challenge')
+    def test_redirect_c3(self, client):
+        response = client.get(url_for('gouvfr.c3'))
+        assert_redirects(response, '/en/climate-change-challenge')
 
-    def test_render_c3_without_data(self):
-        response = self.client.get(url_for('gouvfr.climate_change_challenge'))
-        self.assert200(response)
+    def test_render_c3_without_data(self, client):
+        response = client.get(url_for('gouvfr.climate_change_challenge'))
+        assert200(response)
 
 
-class OpenField16Test(FrontTestCase):
+class OpenField16Test:
     settings = GouvFrSettings
+    modules = []
 
-    def test_render_without_data(self):
-        response = self.client.get(url_for('gouvfr.openfield16'))
-        self.assert200(response)
+    def test_render_without_data(self, client):
+        response = client.get(url_for('gouvfr.openfield16'))
+        assert200(response)
 
-    def test_render_with_data(self):
+    def test_render_with_data(self, client):
         for i in range(3):
             badge = Badge(kind=OPENFIELD16)
             VisibleDatasetFactory(badges=[badge])
-        response = self.client.get(url_for('gouvfr.openfield16'))
-        self.assert200(response)
+        response = client.get(url_for('gouvfr.openfield16'))
+        assert200(response)
 
 
-class SpdTest(FrontTestCase):
+class SpdTest:
     settings = GouvFrSettings
+    modules = []
 
-    def test_render_without_data(self):
-        response = self.client.get(url_for('gouvfr.spd'))
-        self.assert200(response)
+    def test_render_without_data(self, client):
+        response = client.get(url_for('gouvfr.spd'))
+        assert200(response)
 
-    def test_render_with_data(self):
+    def test_render_with_data(self, client):
         for i in range(3):
             badge = Badge(kind=SPD)
             VisibleDatasetFactory(badges=[badge])
-        response = self.client.get(url_for('gouvfr.spd'))
-        self.assert200(response)
+        response = client.get(url_for('gouvfr.spd'))
+        assert200(response)
 
 
 class TerritoriesSettings(GouvFrSettings):
@@ -340,60 +318,59 @@ class TerritoriesSettings(GouvFrSettings):
     HANDLED_LEVELS = ('fr:commune', 'fr:departement', 'fr:region')
 
 
-class TerritoriesTest(FrontTestCase):
+class TerritoriesTest:
     settings = TerritoriesSettings
+    modules = []
 
-    def test_with_gouvfr_town_territory_datasets(self):
+    def test_with_gouvfr_town_territory_datasets(self, client, templates):
         paca, bdr, arles = create_geozones_fixtures()
-        response = self.client.get(
-            url_for('territories.territory', territory=arles))
-        self.assert200(response)
+        url = url_for('territories.territory', territory=arles)
+        with templates.capture():
+            response = client.get(url)
+        assert200(response)
         data = response.data.decode('utf-8')
-        self.assertIn(arles.name, data)
-        base_datasets = self.get_context_variable('base_datasets')
-        self.assertEqual(len(base_datasets), 9)
+        assert arles.name in data
+        base_datasets = templates.get_context_variable('base_datasets')
+        assert len(base_datasets) == 9
+        expected = '<div data-udata-territory-id="{dataset.slug}"'
         for dataset in base_datasets:
-            self.assertIn(
-                '<div data-udata-territory-id="{dataset.slug}"'.format(
-                    dataset=dataset),
-                data)
-        self.assertIn(bdr.name, data)
+            assert expected.format(dataset=dataset) in data
+        assert bdr.name in data
 
-    def test_with_gouvfr_county_territory_datasets(self):
+    def test_with_gouvfr_county_territory_datasets(self, client, templates):
         paca, bdr, arles = create_geozones_fixtures()
-        response = self.client.get(
-            url_for('territories.territory', territory=bdr))
-        self.assert200(response)
+        url = url_for('territories.territory', territory=bdr)
+        with templates.capture():
+            response = client.get(url)
+        assert200(response)
         data = response.data.decode('utf-8')
-        self.assertIn(bdr.name, data)
-        base_datasets = self.get_context_variable('base_datasets')
-        self.assertEqual(len(base_datasets), 7)
+        assert bdr.name in data
+        base_datasets = templates.get_context_variable('base_datasets')
+        assert len(base_datasets) == 7
+        expected = '<div data-udata-territory-id="{dataset.slug}"'
         for dataset in base_datasets:
-            self.assertIn(
-                '<div data-udata-territory-id="{dataset.slug}"'.format(
-                    dataset=dataset),
-                data)
+            assert expected.format(dataset=dataset) in data
 
-    def test_with_gouvfr_region_territory_datasets(self):
+    def test_with_gouvfr_region_territory_datasets(self, client, templates):
         paca, bdr, arles = create_geozones_fixtures()
-        response = self.client.get(
-            url_for('territories.territory', territory=paca))
-        self.assert200(response)
+        url = url_for('territories.territory', territory=paca)
+        with templates.capture():
+            response = client.get(url)
+        assert200(response)
         data = response.data.decode('utf-8')
-        self.assertIn(paca.name, data)
-        base_datasets = self.get_context_variable('base_datasets')
-        self.assertEqual(len(base_datasets), 7)
+        assert paca.name in data
+        base_datasets = templates.get_context_variable('base_datasets')
+        assert len(base_datasets) == 7
+        expected = '<div data-udata-territory-id="{dataset.slug}"'
         for dataset in base_datasets:
-            self.assertIn(
-                '<div data-udata-territory-id="{dataset.slug}"'.format(
-                    dataset=dataset),
-                data)
+            assert expected.format(dataset=dataset) in data
 
 
-class OEmbedsTerritoryAPITest(APITestCase):
+class OEmbedsTerritoryAPITest:
     settings = TerritoriesSettings
+    modules = []
 
-    def test_oembed_town_territory_api_get(self):
+    def test_oembed_town_territory_api_get(self, api):
         '''It should fetch a town territory in the oembed format.'''
         paca, bdr, arles = create_geozones_fixtures()
         licence_ouverte = LicenseFactory(id='fr-lo', title='Licence Ouverte')
@@ -405,40 +382,36 @@ class OEmbedsTerritoryAPITest(APITestCase):
                 id=territory_dataset_class.organization_id)
             territory = territory_dataset_class(arles)
             reference = 'territory-{id}'.format(id=territory.slug)
-            response = self.get(url_for('api.oembeds', references=reference))
-            self.assert200(response)
+            response = api.get(url_for('api.oembeds', references=reference))
+            assert200(response)
             data = json.loads(response.data)[0]
-            self.assertIn('html', data)
-            self.assertIn('width', data)
-            self.assertIn('maxwidth', data)
-            self.assertIn('height', data)
-            self.assertIn('maxheight', data)
-            self.assertTrue(data['type'], 'rich')
-            self.assertTrue(data['version'], '1.0')
-            self.assertIn(territory.title, data['html'])
-            self.assertIn(cgi.escape(territory.url), data['html'])
-            self.assertIn(
-                'alt="{name}"'.format(name=organization.name), data['html'])
-            self.assertIn(
-                md(territory.description, source_tooltip=True), data['html'])
-            self.assertIn('Download from localhost', data['html'])
-            self.assertIn('Add to your own website', data['html'])
+            assert 'html' in data
+            assert 'width' in data
+            assert 'maxwidth' in data
+            assert 'height' in data
+            assert 'maxheight' in data
+            assert data['type'] == 'rich'
+            assert data['version'] == '1.0'
+
+            html = data['html']
+            assert territory.title in html
+            assert cgi.escape(territory.url) in html
+            assert 'alt="{name}"'.format(name=organization.name) in html
+            assert md(territory.description, source_tooltip=True) in html
+            assert 'Download from localhost' in html
+            assert 'Add to your own website' in html
             if territory_dataset_class not in (town_datasets['comptes_com'],):
                 if territory_dataset_class == town_datasets['ban_odbl_com']:
                     license = odbl_license
                 else:
                     license = licence_ouverte
-                self.assertIn(
-                    'License: {title}'.format(title=license.title),
-                    data['html'])
-                self.assertIn(
-                    '© {license_id}'.format(license_id=license.id),
-                    data['html'])
-                self.assertIn(
-                    '<a data-tooltip="Source" href="http://localhost/datasets',
-                    data['html'])
+                assert 'License: {title}'.format(title=license.title) in html
+                assert '© {license_id}'.format(license_id=license.id) in html
+                assert (
+                    '<a data-tooltip="Source" href="http://localhost/datasets'
+                    in html)
 
-    def test_oembed_county_territory_api_get(self):
+    def test_oembed_county_territory_api_get(self, api):
         '''It should fetch a county territory in the oembed format.'''
         paca, bdr, arles = create_geozones_fixtures()
         licence_ouverte = LicenseFactory(id='fr-lo', title='Licence Ouverte')
@@ -448,38 +421,34 @@ class OEmbedsTerritoryAPITest(APITestCase):
                 id=dataset_class.organization_id)
             territory = dataset_class(bdr)
             reference = 'territory-{id}'.format(id=territory.slug)
-            response = self.get(url_for('api.oembeds', references=reference))
-            self.assert200(response)
+            response = api.get(url_for('api.oembeds', references=reference))
+            assert200(response)
             data = json.loads(response.data)[0]
-            self.assertIn('html', data)
-            self.assertIn('width', data)
-            self.assertIn('maxwidth', data)
-            self.assertIn('height', data)
-            self.assertIn('maxheight', data)
-            self.assertTrue(data['type'], 'rich')
-            self.assertTrue(data['version'], '1.0')
-            self.assertIn(territory.title, data['html'])
-            self.assertIn(cgi.escape(territory.url), data['html'])
-            self.assertIn(
-                'alt="{name}"'.format(name=organization.name), data['html'])
-            self.assertIn(
-                md(territory.description, source_tooltip=True), data['html'])
-            self.assertIn('Download from localhost', data['html'])
-            self.assertIn('Add to your own website', data['html'])
+            assert 'html' in data
+            assert 'width' in data
+            assert 'maxwidth' in data
+            assert 'height' in data
+            assert 'maxheight' in data
+            assert data['type'] == 'rich'
+            assert data['version'] == '1.0'
+
+            html = data['html']
+            assert territory.title in html
+            assert cgi.escape(territory.url) in html
+            assert 'alt="{name}"'.format(name=organization.name) in html
+            assert md(territory.description, source_tooltip=True) in html
+            assert 'Download from localhost' in html
+            assert 'Add to your own website' in html
             if dataset_class not in (
                     TERRITORY_DATASETS['departement']['comptes_dep'],
                     TERRITORY_DATASETS['departement']['zonages_dep']):
-                self.assertIn(
-                    'License: {title}'.format(title=licence_ouverte.title),
-                    data['html'])
-                self.assertIn(
-                    '© {license_id}'.format(license_id=licence_ouverte.id),
-                    data['html'])
-                self.assertIn(
-                    '<a data-tooltip="Source" href="http://localhost/datasets',
-                    data['html'])
+                assert 'License: {0}'.format(licence_ouverte.title) in html
+                assert '© {0}'.format(licence_ouverte.id) in html
+                assert (
+                    '<a data-tooltip="Source" href="http://localhost/datasets'
+                    in html)
 
-    def test_oembed_region_territory_api_get(self):
+    def test_oembed_region_territory_api_get(self, api):
         '''It should fetch a region territory in the oembed format.'''
         paca, bdr, arles = create_geozones_fixtures()
         licence_ouverte = LicenseFactory(id='fr-lo', title='Licence Ouverte')
@@ -489,135 +458,131 @@ class OEmbedsTerritoryAPITest(APITestCase):
                 id=territory_dataset_class.organization_id)
             territory = territory_dataset_class(paca)
             reference = 'territory-{id}'.format(id=territory.slug)
-            response = self.get(url_for('api.oembeds', references=reference))
-            self.assert200(response)
+            response = api.get(url_for('api.oembeds', references=reference))
+            assert200(response)
             data = json.loads(response.data)[0]
-            self.assertIn('html', data)
-            self.assertIn('width', data)
-            self.assertIn('maxwidth', data)
-            self.assertIn('height', data)
-            self.assertIn('maxheight', data)
-            self.assertTrue(data['type'], 'rich')
-            self.assertTrue(data['version'], '1.0')
-            self.assertIn(territory.title, data['html'])
-            self.assertIn(cgi.escape(territory.url), data['html'])
-            self.assertIn(
-                'alt="{name}"'.format(name=organization.name), data['html'])
-            self.assertIn(
-                md(territory.description, source_tooltip=True), data['html'])
-            self.assertIn('Download from localhost', data['html'])
-            self.assertIn('Add to your own website', data['html'])
+            assert 'html' in data
+            assert 'width' in data
+            assert 'maxwidth' in data
+            assert 'height' in data
+            assert 'maxheight' in data
+            assert data['type'] == 'rich'
+            assert data['version'] == '1.0'
+
+            html = data['html']
+            assert territory.title in html
+            assert cgi.escape(territory.url) in html
+            assert 'alt="{name}"'.format(name=organization.name) in html
+            assert md(territory.description, source_tooltip=True) in html
+            assert 'Download from localhost' in html
+            assert 'Add to your own website' in html
             if territory_dataset_class not in (
                     TERRITORY_DATASETS['region']['comptes_reg'],
                     TERRITORY_DATASETS['region']['zonages_reg']):
-                self.assertIn(
-                    'License: {title}'.format(title=licence_ouverte.title),
-                    data['html'])
-                self.assertIn(
-                    '© {license_id}'.format(license_id=licence_ouverte.id),
-                    data['html'])
-                self.assertIn(
-                    '<a data-tooltip="Source" href="http://localhost/datasets',
-                    data['html'])
+                assert 'License: {0}'.format(licence_ouverte.title) in html
+                assert '© {0}'.format(licence_ouverte.id) in html
+                assert (
+                    '<a data-tooltip="Source" href="http://localhost/datasets'
+                    in html)
 
 
-class SpatialTerritoriesApiTest(APITestCase):
+class SpatialTerritoriesApiTest:
     settings = TerritoriesSettings
+    modules = []
 
-    def test_zone_datasets_with_dynamic_region(self):
+    def test_datasets_with_dynamic_region(self, autoindex, client):
         paca, bdr, arles = create_geozones_fixtures()
-        with self.autoindex():
+        with autoindex:
             organization = OrganizationFactory()
             for _ in range(3):
                 VisibleDatasetFactory(
                     organization=organization,
                     spatial=SpatialCoverageFactory(zones=[paca.id]))
 
-        response = self.get(
-            url_for('api.zone_datasets', id=paca.id), qs={'dynamic': 1})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 10)
+        response = client.get(url_for('api.zone_datasets', id=paca.id),
+                              qs={'dynamic': 1})
+        assert200(response)
+        assert len(response.json) == 10
 
-    def test_zone_datasets_with_dynamic_region_and_size(self):
+    def test_datasets_with_dynamic_region_and_size(self, autoindex, client):
         paca, bdr, arles = create_geozones_fixtures()
-        with self.autoindex():
+        with autoindex:
             organization = OrganizationFactory()
             for _ in range(3):
                 VisibleDatasetFactory(
                     organization=organization,
                     spatial=SpatialCoverageFactory(zones=[paca.id]))
 
-        response = self.get(
-            url_for('api.zone_datasets', id=paca.id),
-            qs={'dynamic': 1, 'size': 2})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 9)
+        response = client.get(url_for('api.zone_datasets', id=paca.id),
+                              qs={'dynamic': 1, 'size': 2})
+        assert200(response)
+        assert len(response.json) == 9
 
-    def test_zone_datasets_without_dynamic_region(self):
+    def test_datasets_without_dynamic_region(self, autoindex, client):
         paca, bdr, arles = create_geozones_fixtures()
-        with self.autoindex():
+        with autoindex:
             organization = OrganizationFactory()
             for _ in range(3):
                 VisibleDatasetFactory(
                     organization=organization,
                     spatial=SpatialCoverageFactory(zones=[paca.id]))
 
-        response = self.get(
-            url_for('api.zone_datasets', id=paca.id))
-        self.assert200(response)
-        self.assertEqual(len(response.json), 3)
+        response = client.get(url_for('api.zone_datasets', id=paca.id))
+        assert200(response)
+        assert len(response.json) == 3
 
-    def test_zone_datasets_with_dynamic_county(self):
+    def test_datasets_with_dynamic_county(self, autoindex, client):
         paca, bdr, arles = create_geozones_fixtures()
-        with self.autoindex():
+        with autoindex:
             organization = OrganizationFactory()
             for _ in range(3):
                 VisibleDatasetFactory(
                     organization=organization,
                     spatial=SpatialCoverageFactory(zones=[bdr.id]))
 
-        response = self.get(
-            url_for('api.zone_datasets', id=bdr.id), qs={'dynamic': 1})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 10)
+        response = client.get(url_for('api.zone_datasets', id=bdr.id),
+                              qs={'dynamic': 1})
+        assert200(response)
+        assert len(response.json) == 10
 
-    def test_zone_datasets_with_dynamic_town(self):
+    def test_datasets_with_dynamic_town(self, autoindex, client):
         paca, bdr, arles = create_geozones_fixtures()
-        with self.autoindex():
+        with autoindex:
             organization = OrganizationFactory()
             for _ in range(3):
                 VisibleDatasetFactory(
                     organization=organization,
                     spatial=SpatialCoverageFactory(zones=[arles.id]))
 
-        response = self.get(
-            url_for('api.zone_datasets', id=arles.id), qs={'dynamic': 1})
-        self.assert200(response)
-        self.assertEqual(len(response.json), 12)
+        response = client.get(url_for('api.zone_datasets', id=arles.id),
+                              qs={'dynamic': 1})
+        assert200(response)
+        assert len(response.json) == 12
 
-    def test_zone_children(self):
+    def test_zone_children(self, client):
         paca, bdr, arles = create_geozones_fixtures()
 
-        response = self.get(url_for('api.zone_children', id=paca.id))
-        self.assert200(response)
-        self.assertEqual(response.json['features'][0]['id'], bdr.id)
+        response = client.get(url_for('api.zone_children', id=paca.id))
+        assert200(response)
+        assert response.json['features'][0]['id'] == bdr.id
 
-        response = self.get(url_for('api.zone_children', id=bdr.id))
-        self.assert200(response)
-        self.assertEqual(response.json['features'][0]['id'], arles.id)
+        response = client.get(url_for('api.zone_children', id=bdr.id))
+        assert200(response)
+        assert response.json['features'][0]['id'] == arles.id
 
-        response = self.get(url_for('api.zone_children', id=arles.id))
-        self.assert200(response)
-        self.assertEqual(response.json['features'], [])
+        response = client.get(url_for('api.zone_children', id=arles.id))
+        assert200(response)
+        assert response.json['features'] == []
 
 
-class SitemapTest(FrontTestCase):
+class SitemapTest:
     settings = GouvFrSettings
+    modules = []
 
-    def test_urls_within_sitemap(self):
+    def test_urls_within_sitemap(self, client):
         '''It should add gouvfr pages to sitemap.'''
-        response = self.get('sitemap.xml')
-        self.assert200(response)
+        response = client.get('sitemap.xml')
+        assert200(response)
 
         urls = [
             url_for('gouvfr.credits_redirect', _external=True),
@@ -630,32 +595,33 @@ class SitemapTest(FrontTestCase):
                                 section=section, _external=True))
 
         for url in urls:
-            self.assertIn('<loc>{url}</loc>'.format(url=url), response.data)
+            assert '<loc>{url}</loc>'.format(url=url) in response.data
 
 
-class SitemapTerritoriesTest(SitemapTestCase):
+class SitemapTerritoriesTest:
     settings = TerritoriesSettings
+    modules = []
 
-    def test_towns_within_sitemap(self):
+    def test_towns_within_sitemap(self, sitemap):
         '''It should return the towns from the sitemap.'''
         paca, bdr, arles = create_geozones_fixtures()
-        self.get_sitemap_tree()
-        url = self.get_by_url('territories.territory', territory=arles)
-        self.assertIsNotNone(url)
-        self.assert_url(url, 0.5, 'weekly')
+        sitemap.fetch()
+        url = sitemap.get_by_url('territories.territory', territory=arles)
+        assert url is not None
+        sitemap.assert_url(url, 0.5, 'weekly')
 
-    def test_counties_within_sitemap(self):
+    def test_counties_within_sitemap(self, sitemap):
         '''It should return the counties from the sitemap.'''
         paca, bdr, arles = create_geozones_fixtures()
-        self.get_sitemap_tree()
-        url = self.get_by_url('territories.territory', territory=bdr)
-        self.assertIsNotNone(url)
-        self.assert_url(url, 0.5, 'weekly')
+        sitemap.fetch()
+        url = sitemap.get_by_url('territories.territory', territory=bdr)
+        assert url is not None
+        sitemap.assert_url(url, 0.5, 'weekly')
 
-    def test_regions_within_sitemap(self):
+    def test_regions_within_sitemap(self, sitemap):
         '''It should return the regions from the sitemap.'''
         paca, bdr, arles = create_geozones_fixtures()
-        self.get_sitemap_tree()
-        url = self.get_by_url('territories.territory', territory=paca)
-        self.assertIsNotNone(url)
-        self.assert_url(url, 0.5, 'weekly')
+        sitemap.fetch()
+        url = sitemap.get_by_url('territories.territory', territory=paca)
+        assert url is not None
+        sitemap.assert_url(url, 0.5, 'weekly')


### PR DESCRIPTION
This PR migrate test to pure pytest syntax (enabling use of `fixtures` and other pytest features)

(Requires some changes in opendatateam/udata#1428)