### PR TITLE
Remove useless style and adapt new reuse add card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Make use of [udata pytest plugin](https://github.com/opendatateam/udata#1400) [#254](https://github.com/etalab/udata-gouvfr/pull/254)
 - Expose new entrypoints. Plugins and theme translations are now splitted [#263](https://github.com/etalab/udata-gouvfr/pull/263)
-- Align card components design [#252](https://github.com/etalab/udata-gouvfr/pull/252)
+- Align card components design [#252](https://github.com/etalab/udata-gouvfr/pull/252) [#272](https://github.com/etalab/udata-gouvfr/pull/272)
 - Discourse timeout and response parse error catch [#267](https://github.com/etalab/udata-gouvfr/pull/267)
 - Add tracking on home page call to action [#271](https://github.com/etalab/udata-gouvfr/pull/271)
 - Add tracking on carousel elements [#268](https://github.com/etalab/udata-gouvfr/pull/268)

--- a/theme/less/gouvfr-admin.less
+++ b/theme/less/gouvfr-admin.less
@@ -1,3 +1,6 @@
+@import "gouvfr/variables";
+@import "gouvfr/cards";
+
 // Style admin header
 .skin-blue {
     //Navbar

--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -12,6 +12,7 @@
 @import "gouvfr/licences";
 @import "gouvfr/resources";
 @import "gouvfr/community";
+@import "gouvfr/cards";
 
 @import "gouvfr-home";
 @import "gouvfr-dataset";

--- a/theme/less/gouvfr/cards.less
+++ b/theme/less/gouvfr/cards.less
@@ -1,0 +1,50 @@
+.card {
+    border-bottom-color: @default-concept-color;
+    border-bottom-width: 2px;
+
+    &:hover, &.selected {
+        border-color: @link-hover-color;
+    }
+
+    &.dataset-card {
+        border-bottom-color: @dataset-color;
+        &:hover, &.selected {
+            border-color: @dataset-color;
+        }
+    }
+
+    &.reuse-card {
+        border-bottom-color: @reuse-color;
+        &:hover, &.selected {
+            border-color: @reuse-color;
+        }
+    }
+
+    &.resource-card {
+        border-bottom-color: @resource-color;
+        &:hover, &.selected {
+            border-color: @resource-color;
+        }
+    }
+
+    &.organization-card {
+        border-bottom-color: @organization-color;
+        &:hover, &.selected {
+            border-color: @organization-color;
+        }
+    }
+
+    &.territory-card {
+        border-bottom-color: @territory-color;
+        &:hover, &.selected {
+            border-color: @territory-color;
+        }
+    }
+
+    &.user-card {
+        border-bottom-color: @user-color;
+        &:hover, &.selected {
+            border-color: @user-color;
+        }
+    }
+}

--- a/theme/less/gouvfr/community.less
+++ b/theme/less/gouvfr/community.less
@@ -110,7 +110,7 @@
                 color: #7d8489;
             }
 
-            .card__cover {
+            .card-cover {
                 color: #7d8489;
                 background-color: rgba(255,255,255,0.05);
             }

--- a/theme/less/gouvfr/community.less
+++ b/theme/less/gouvfr/community.less
@@ -101,147 +101,22 @@
     }
 
     .reuses-list {
-        .reuse {
-            border-radius: 0px;
-            border: none;
-            height: 210px;
-            margin-bottom: 20px;
-            overflow: hidden;
-            background-color: #fafafa;
-            padding: 0px;
-            position: relative;
-
-            @preview-height: 110px;
-
-            a.preview {
-                display: block;
-                height: @preview-height;
-                text-align: center;
-                overflow: hidden;
-
-                img {
-                    min-height: @preview-height;
-                    min-width: 100%;
-
-                }
-            }
-
-            .caption {
-                padding: 13px;
-                color: #6B6B6B;
-                font-size: 13px;
-                line-height: 16px;
-
-                .author {
-                    display: block;
-                    height: 28px;
-                    position: absolute;
-                    bottom: 8px;
-
-                    .avatar {
-                        .text-center();
-                        float: left;
-                        width: 25px;
-                        height: 25px;
-                        border: 1px solid #7e7e7e;
-                        margin-right: 10px;
-                        z-index: 150; // Fix hover reactivity
-
-                        img {
-                            max-width: 100%;
-                            max-height: 100%;
-                        }
-                    }
-
-                    .user {
-                        font-size: 13px;
-                        color: #3a3b3d;
-                        font-weight: bold;
-                        top: -3px;
-                        position: relative;
-                    }
-                    .date {
-                        display: block;
-                        font-size: 10px;
-                        top: -5px;
-                        position: relative;
-                        white-space: nowrap;
-                    }
-                }
-            }
-
-            &.add {
-                @border-size: 2px;
-                background: none;
-                border: @border-size dashed #7d8489;
-
-                h4 {
-                    text-align: center;
-                    font-size: 15px;
-                    color: #7d8489;
-                    line-height: 2.6em;
-                    padding-top: 10px;
-                }
-
-                .preview {
-                    color: #7d8489;
-                    background-color: rgba(255,255,255,0.05);
-                    text-align: center;
-                    font-size: 36px;
-                    font-weight: bold;
-                    line-height: 100px;
-                    height: @preview-height - @border-size;
-                }
-
-                &:hover {
-                    background-color: rgba(255,255,255,0.04);
-                    text-decoration: none;
-                }
-            }
-
-            .rollover {
-                color: darken(white, 10%);
-                background: fadeout(@gray-darker, 15%);
-                font-size: 13px;
-                position: absolute;
-                display: none;
-                top: 0;
-                left: 0;
-                right: 0;
-                height: @preview-height;
-                padding: 10px;
-                overflow: hidden;
-
-                &:hover {
-                    text-decoration: none;
-                    background: fadeout(@gray-darker, 10%);
-                }
-            }
-
-            &:hover .rollover {
-                display: block;
-            }
+        .add {
+            @border-size: 2px;
+            background: none;
+            border: @border-size dashed #7d8489;
 
             h4 {
-                margin-top: 4px;
-                margin-bottom: 7px;
-                line-height: 10px;
-                max-height: 34px;
-
-                a {
-                    font-family: @title-font;
-                    font-size: 14px;
-                    line-height: 1.2em !important;
-                    color: #131416;
-                    font-weight: bold;
-                    display: block;
-                }
+                color: #7d8489;
             }
 
-            .btn-group {
-                position: absolute;
-                right: 10px;
-                bottom: 10px;
+            .card__cover {
+                color: #7d8489;
+                background-color: rgba(255,255,255,0.05);
+            }
+
+            &:hover {
+                background-color: rgba(255,255,255,0.04);
             }
         }
 	}

--- a/theme/less/gouvfr/resources.less
+++ b/theme/less/gouvfr/resources.less
@@ -14,7 +14,7 @@
             background-color: #ddd;
         }
 
-        &.add {
+        &.add, .community_container &.add {
             @add-base-color: darken(@base-color, 30%);
             background-color: fadeout(@add-base-color, 92%);
             border: 2px dashed @add-base-color;

--- a/theme/less/gouvfr/variables.less
+++ b/theme/less/gouvfr/variables.less
@@ -20,6 +20,9 @@
 @green: #81c85b;
 @red: #ec364b;
 @yellow: #ffb311;
+@orange:     #FF851B;
+@olive:      #3D9970;
+@fuchsia:    #F012BE;
 
 
 /*
@@ -64,3 +67,12 @@
 @nav-pills-border-radius:                   0;
 @nav-pills-active-link-hover-bg:            #fff;
 @nav-pills-active-link-hover-color:         @btn-primary-bg;
+
+// Base colors
+@default-concept-color:   #C9D3DF;
+@dataset-color:           #0081D5;
+@resource-color:          #FF9947;
+@organization-color:      #03BD5B;
+@territory-color:         @fuchsia;
+@user-color:              @olive;
+@reuse-color:             #D1335B;


### PR DESCRIPTION
This PR follow changes from opendatateam/udata#1460

## Responsive degradation and footer

### Wide

| Before | After |
|----------|--------|
| ![screenshot-data xps-2018 02 21-20-09-46](https://user-images.githubusercontent.com/15725/36501109-8b924bea-1746-11e8-8e4c-585779aae3eb.png) | ![screenshot-data xps-2018 02 21-20-12-45](https://user-images.githubusercontent.com/15725/36501119-9237da1e-1746-11e8-9af7-c18bad7ef0ab.png) |

### Narrow

| Before | After |
|----------|--------|
| ![screenshot-data xps-2018 02 21-20-10-18](https://user-images.githubusercontent.com/15725/36501125-95efcf36-1746-11e8-8033-02f3bb8a2ade.png) | ![screenshot-data xps-2018 02 21-20-12-10](https://user-images.githubusercontent.com/15725/36501127-9810169a-1746-11e8-8469-35773213e26d.png) |

## Reuse add button
Fix style to match cards size

| Before | After |
|----------|--------|
| ![screenshot-data xps-2018 02 21-20-09-09](https://user-images.githubusercontent.com/15725/36501150-a0fd55ec-1746-11e8-9978-cd601bb93307.png) | ![screenshot-data xps-2018 02 21-20-11-33](https://user-images.githubusercontent.com/15725/36501153-a331f3c2-1746-11e8-9080-533f129505e2.png) |


## Cleanup
Removes unused legacy style

Connects to opendatateam/udata#1460