### PR TITLE
Drop non-certified style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Limit number of forum topics [284](https://github.com/etalab/udata-gouvfr/pull/284)
 - Use new OEmbed cards in datasets recommandations [#285](https://github.com/etalab/udata-gouvfr/pull/285)
 - Fix the RSS popover not being clickable [#287](https://github.com/etalab/udata-gouvfr/pull/287)
+- Drop the custom style for non-certified datasets [#288](https://github.com/etalab/udata-gouvfr/pull/288)
 
 ## 1.3.1 (2018-03-15)
 

--- a/theme/less/gouvfr-dataset.less
+++ b/theme/less/gouvfr-dataset.less
@@ -314,34 +314,6 @@ body.dataset-display {
         }
     }
 
-    .noncertified {
-        background-color: #eef7f7 !important;
-        background-image: url('/img/bgpt_noncertied.png');
-
-        .card {
-            background: none !important;
-        }
-
-        .dataset-container .resources-list .list-group-item {
-            &:not(.add) {
-                background-color: #e0e3e9;
-                border-color: #e8e8e8;
-            }
-
-            &.add {
-                background-color: fadeout(@gray-light, 95%);
-                &:hover {
-                    background-color: fadeout(@gray-light, 90%);
-                }
-            }
-
-        }
-
-        .btn-default {
-            background: none !important;
-        }
-    }
-
     .label-list.tags a {
         margin-right: 2px;
         margin-bottom: 3px;


### PR DESCRIPTION
Drop the not so visible non-certified custom style on datasets pages.