### PR TITLE
Add "suivi" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use new pypi.org links [#295](https://github.com/etalab/udata-gouvfr/pull/295)
 - Ensure active users have a confirmed_at date (migration) [#298](https://github.com/etalab/udata-gouvfr/pull/298)
 - Remove credits page [#306](https://github.com/etalab/udata-gouvfr/pull/306)
+- Add tracking and privacy page [#310](https://github.com/etalab/udata-gouvfr/pull/310)
 
 ## 1.3.2 (2018-03-28)
 

--- a/theme/less/gouvfr.less
+++ b/theme/less/gouvfr.less
@@ -13,6 +13,7 @@
 @import "gouvfr/resources";
 @import "gouvfr/community";
 @import "gouvfr/cards";
+@import "gouvfr/suivi";
 
 @import "gouvfr-home";
 @import "gouvfr-dataset";

--- a/theme/less/gouvfr/suivi.less
+++ b/theme/less/gouvfr/suivi.less
@@ -1,0 +1,11 @@
+@import "./variables";
+
+.suivi {
+    .optout {
+        background-color: @bg-gray;
+        width: 100%;
+        border-width: 0;
+        border-radius: 8px;
+        padding: 1em;
+    }
+}

--- a/udata_gouvfr/templates/suivi.html
+++ b/udata_gouvfr/templates/suivi.html
@@ -1,0 +1,54 @@
+{% extends theme("base.html") %}
+
+{% set meta = {
+    'title': "Suivi d'audience et vie privée",
+    'description': "Suivi d'audience et vie privée sur data.gouv.fr",
+} %}
+
+{% block breadcrumb %}
+    <li class="active">Redevances</li>
+{% endblock %}
+
+{% block content %}
+<section class="default">
+    <div class="container">
+        <div class="row">
+            <article class="suivi col-sm-12">
+                <h1>Suivi d'audience et vie privée</h1>
+
+                <h2>Cookies déposés et opt-out</h2>
+
+                <p class="text-justify">
+                Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez.
+                Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.
+                </p>
+
+                <iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr"></iframe>
+
+                <h2>Ce site n'affiche pas de bannière de consentement aux cookies, pourquoi ?</h2>
+
+                <p class="text-justify">
+                C'est vrai, vous n'avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d'accord avec le dépôt de cookies — même si vous ne savez pas ce que ça veut dire !
+                </p>
+
+                <p class="text-justify">
+                Rien d'exceptionnel, pas de passe-droit lié à un <code>.gouv.fr</code>. Nous respectons simplement la loi, qui dit que certains outils de suivi d'audience, correctement configurés pour respecter la vie privée, sont exemptés d'autorisation préalable.
+                </p>
+
+                <p class="text-justify">
+                Nous utilisons pour cela <a href="https://matomo.org">Matomo</a>, un outil <a href="https://matomo.org/free-software/">libre</a>,
+                paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies »</a>
+                de la <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d'être enregistrée.
+                Il est donc impossible d'associer vos visites sur ce site à votre personne.
+                </p>
+
+                <h2>Je contribue à enrichir vos données, puis-je y accéder ?</h2>
+                <p class="text-justify">
+                Bien sûr ! Les statistiques d’usage sont disponibles en accès libre sur <a href="https://stats.data.gouv.fr">stats.data.gouv.fr</a>.
+                </p>
+
+            </article>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/udata_gouvfr/templates/suivi.html
+++ b/udata_gouvfr/templates/suivi.html
@@ -28,11 +28,7 @@
                 <h2>Ce site n'affiche pas de bannière de consentement aux cookies, pourquoi ?</h2>
 
                 <p class="text-justify">
-                C'est vrai, vous n'avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d'accord avec le dépôt de cookies — même si vous ne savez pas ce que ça veut dire !
-                </p>
-
-                <p class="text-justify">
-                Rien d'exceptionnel, pas de passe-droit lié à un <code>.gouv.fr</code>. Nous respectons simplement la loi, qui dit que certains outils de suivi d'audience, correctement configurés pour respecter la vie privée, sont exemptés d'autorisation préalable.
+                Nous respectons simplement la loi, qui dit que certains outils de suivi d'audience, correctement configurés pour respecter la vie privée, sont exemptés d'autorisation préalable.
                 </p>
 
                 <p class="text-justify">

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -42,6 +42,7 @@ nav.Bar('gouvfr_footer', [
     nav.Item(_('Licences'), 'gouvfr.licences'),
     nav.Item(_('API'), 'apidoc.swaggerui'),
     nav.Item(_('Terms of use'), 'site.terms'),
+    nav.Item(_('Tracking and privacy'), 'gouvfr.suivi'),
 ])
 
 NETWORK_LINKS = [

--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -184,6 +184,14 @@ def licences():
         abort(404)
 
 
+@blueprint.route('/suivi')
+def suivi():
+    try:
+        return theme.render('suivi.html')
+    except TemplateNotFound:
+        abort(404)
+
+
 @blueprint.route('/faq/', defaults={'section': 'home'})
 @blueprint.route('/faq/<string:section>/')
 def faq(section):


### PR DESCRIPTION
This is almost identical to https://beta.gouv.fr/suivi/, which I find 👌.

I renamed Piwik to Matomo and updated the links.

I removed
> de la majorité de nos produits, dont beta.gouv.fr

I think we can also remove this sentence, which may not have the adequate "tone" for our site:
> C’est vrai, vous n’avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d’accord avec le dépôt de cookies — même si vous ne savez pas ce que ça veut dire !

@ThomasMenant, is this page OK from a legal point of view?