### PR TITLE
Fix modal-lg width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use new pypi.org links [#295](https://github.com/etalab/udata-gouvfr/pull/295)
 - Ensure active users have a confirmed_at date (migration) [#298](https://github.com/etalab/udata-gouvfr/pull/298)
 - Remove credits page [#306](https://github.com/etalab/udata-gouvfr/pull/306)
+- Fix `modal-lg` width [#311](https://github.com/etalab/udata-gouvfr/pull/311)
 
 ## 1.3.2 (2018-03-28)
 

--- a/theme/less/gouvfr/modals.less
+++ b/theme/less/gouvfr/modals.less
@@ -1,11 +1,5 @@
 // Custom modal style
 .modal {
-    @media(min-width: @screen-lg-min) {
-        .modal-dialog {
-            width: 700px;
-        }
-    }
-
     .modal-header, .modal-footer {
         padding: 12px;
         background-color: lighten(@bg-light, 45%);


### PR DESCRIPTION
This PR remove the hard-coded modal width and so fixes modals with `modal-lg` class width.