### PR TITLE
Ajout de l'arrêté SPD du 14 juin 2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add a reference on the page about SPD [#318]https://github.com/etalab/udata-gouvfr/pull/318)
 
 ## 1.4.1 (2018-06-06)
 

--- a/udata_gouvfr/templates/spd.html
+++ b/udata_gouvfr/templates/spd.html
@@ -104,6 +104,7 @@
                 <ul class="list-unstyled">
                     <li><a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000033205649&dateTexte=29990101&categorieLien=cid">L’article L321-4 du Code des relations entre le public et les administrations</a></li>
                     <li><a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000034194946&categorieLien=id">Le décret d’application 2017-331 du 14 mars 2017 relatif au service public de mise à disposition des données de référence</a></li>
+                    <li><a href="https://www.legifrance.gouv.fr/eli/arrete/2017/6/14/PRMJ1713859A/jo/texte">L'arrêté du 14 juin 2017 relatif aux règles techniques et d'organisation de mise à disposition des données de référence prévues à l'article L. 321-4 du code des relations entre le public et l'administration</a></li>
                     <li><a href="http://www.etalab.gouv.fr/consultation-spd">La synthèse de la consultation publique organisée par Etalab en octobre 2016</a></li>
                 </ul>
             </aside>


### PR DESCRIPTION
La page SPD ne listait que l'article du CRPA et le décret, il manquait l'arrêté.