### PR TITLE
Fix the navbar toggle button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix the navbar toggle button position 🎊 [#327](https://github.com/etalab/udata-gouvfr/pull/327)
 
 ## 1.4.2 (2018-07-30)
 

--- a/theme/less/gouvfr/navbars.less
+++ b/theme/less/gouvfr/navbars.less
@@ -99,6 +99,13 @@
         padding-top: 6px;
         vertical-align: bottom;
     }
+
+    .navbar-toggle {
+        position: absolute;
+        right: -5px;
+        top: 10px;
+        margin-right: 0;
+    }
 }
 
 .navbar-default {


### PR DESCRIPTION
This PR fixes an old bug about the top navbar toggle button position (mobile only) and align it on the grid/layout.

## Before
<kbd><img src="https://user-images.githubusercontent.com/15725/43730660-5b1bf98c-99ac-11e8-9a3e-fcdf2531fe1b.png" /></kbd>

## After
<kbd><img src="https://user-images.githubusercontent.com/15725/43730761-b2941dc0-99ac-11e8-89e3-c5b4951d776b.png" /></kbd>

