### PR TITLE
Add assets manifest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bower
 /static/
 node_modules
 /udata_gouvfr/theme/static/
+/udata_gouvfr/theme/manifest.json
 
 # Installer logs
 pip-log.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Make use of assets manifest for long term caching [#328](https://github.com/etalab/udata-gouvfr/pull/328)
 
 ## 1.4.3 (2018-08-08)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "less-loader": "^2.2.2",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.11",
-    "webpack-fail-plugin": "^2.0.0"
+    "webpack-fail-plugin": "^2.0.0",
+    "webpack-manifest-plugin": "^1.3.2"
   },
   "dependencies": {
     "bootstrap": "^3.3.7"

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,2 @@
-udata>=1.4.2.dev,<2.0.0
+udata>=1.6.0.dev,<2.0.0
 feedparser==5.2.1

--- a/udata_gouvfr/theme/templates/admin.html
+++ b/udata_gouvfr/theme/templates/admin.html
@@ -1,8 +1,8 @@
-{% extends "raw.html" %}
+{% extends "admin.html" %}
 
 {% block theme_css %}
 {{ super() }}
-<link href="{{ manifest('theme', 'theme.css') }}" rel="stylesheet">
+<link href="{{ manifest('theme', 'admin.css') }}" rel="stylesheet">
 {% endblock %}
 
 {% block raw_head %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,17 @@
-var path = require('path');
-var webpack = require('webpack');
+const path = require('path');
+const webpack = require('webpack');
 
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var node_path = path.join(__dirname, 'node_modules');
-var static_path = path.join(__dirname, 'udata_gouvfr', 'theme', 'static');
-var source_path = path.join(__dirname, 'theme');
+const ManifestPlugin = require('webpack-manifest-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const node_path = path.join(__dirname, 'node_modules');
+const theme_path = path.join(__dirname, 'udata_gouvfr', 'theme');
+const static_path = path.join(theme_path, 'static');
+const source_path = path.join(__dirname, 'theme');
+const public_path = '/_themes/gouvfr/'
 
-var css_loader = ExtractTextPlugin.extract('style', 'css?root='+source_path+'&sourceMap'),
-    less_loader = ExtractTextPlugin.extract('style', 'css?root='+source_path+'&sourceMap!less?sourceMap=source-map-less-inline');
+const css_loader = ExtractTextPlugin.extract('style', 'css?root='+source_path+'&sourceMap');
+const less_loader = ExtractTextPlugin.extract('style', 'css?root='+source_path+'&sourceMap!less?sourceMap=source-map-less-inline');
+
 
 module.exports = {
     context: source_path,
@@ -18,8 +22,9 @@ module.exports = {
     },
     output: {
         path: static_path,
-        publicPath: "/_themes/gouvfr/",
-        filename: "[name].js"
+        publicPath: public_path,
+        filename: "[name].[hash].js",
+        chunkFilename: 'chunks/[id].[hash].js'
     },
     resolve: {
         root: source_path
@@ -45,7 +50,13 @@ module.exports = {
         plugins: ['transform-runtime']
     },
     plugins: [
-        new ExtractTextPlugin('[name].css'),
+        new ManifestPlugin({
+            fileName: path.join(theme_path, 'manifest.json'),
+            // Filter out chunks and source maps
+            filter: ({name, isInitial, isChunk}) => !name.endsWith('.map') && (isInitial || !isChunk),
+            publicPath: public_path,
+        }),
+        new ExtractTextPlugin('[name].[contenthash].css'),
         require('webpack-fail-plugin'),
     ]
 };


### PR DESCRIPTION
This PR adds assets manifest support to the webpack build and 1.6 compatibility (adds `theme.css` to the `raw.html` template and `admin.css` to the `admin.html` template).

Connects to opendatateam/udata#1826

Tests won't pass until opendatateam/udata#1826 is merged (might require a CircleCI cache flush)