### PR TITLE
Discussion add card style coherence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Make use of assets manifest for long term caching [#328](https://github.com/etalab/udata-gouvfr/pull/328)
-- Discussion add card style coherence
+- Discussion add card style coherence [#339](https://github.com/etalab/udata-gouvfr/pull/339)
 
 ## 1.4.4 (2018-08-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Make use of assets manifest for long term caching [#328](https://github.com/etalab/udata-gouvfr/pull/328)
+- Discussion add card style coherence
 
 ## 1.4.4 (2018-08-27)
 

--- a/theme/less/gouvfr/cards.less
+++ b/theme/less/gouvfr/cards.less
@@ -31,6 +31,12 @@
         }
     }
 
+    &.discussion-card {
+        &:hover, &.selected {
+            border-color: @discussion-color;
+        }
+    }
+
     &.organization-card {
         border-bottom-color: @organization-color;
         &:hover, &.selected {

--- a/theme/less/gouvfr/community.less
+++ b/theme/less/gouvfr/community.less
@@ -45,7 +45,7 @@
         font-size: 13px;
     }
 
-    .reuses-list, .resources-list {
+    .reuses-list, .resources-list, .discussion-threads {
         .add {
             @border-size: 2px;
             background: none;
@@ -57,7 +57,7 @@
 
             .card-cover, .card-logo {
                 color: #7d8489;
-                background-color: rgba(255,255,255,0.05);
+                background-color: rgba(255,255,255,0.05) !important;
             }
 
             &:hover {

--- a/theme/less/gouvfr/variables.less
+++ b/theme/less/gouvfr/variables.less
@@ -76,3 +76,4 @@
 @territory-color:         @fuchsia;
 @user-color:              @olive;
 @reuse-color:             #D1335B;
+@discussion-color:        @dataset-color;


### PR DESCRIPTION
Cf https://github.com/opendatateam/udata/pull/1884

ATM I kept the resource color (blue), any idea on a new one for discussions?

## Before

<img width="878" alt="capture d ecran 2018-09-11 11 33 55" src="https://user-images.githubusercontent.com/119625/45351755-305f6180-b5b7-11e8-83d5-a2253b822e8c.png">

## After

<img width="774" alt="capture d ecran 2018-09-11 11 33 37" src="https://user-images.githubusercontent.com/119625/45351745-2b9aad80-b5b7-11e8-925b-e3cab9452881.png">
