### PR TITLE
Improved RSS/Atom parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Home blog post extraction improvements. Supports both Atom and RSS 2.0, more image tag formats, `media:thumbnail` and enclosures. [#385](https://github.com/etalab/udata-gouvfr/pull/385)
 
 ## 1.6.4 (2019-03-27)
 

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,7 @@
 mock==2.0.0
 pytest==4.3.1
 pytest-flask==0.14.0
+pytest-mock==1.10.3
 pytest-sugar==0.9.2
 requests-mock==1.5.2
+feedgen==0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ python_classes = *Test
 
 [flake8]
 exclude = doc,.git
+max_line_length = 100
 
 [wheel]
 universal = 1

--- a/udata_gouvfr/tests.py
+++ b/udata_gouvfr/tests.py
@@ -4,9 +4,11 @@ import cgi
 import json
 
 import pytest
+import pytz
 import requests
 
 from flask import url_for
+from feedgen.feed import FeedGenerator
 from werkzeug.contrib.atom import AtomFeed
 
 from udata.core.dataset.factories import (
@@ -22,7 +24,7 @@ from udata.tests.features.territories.test_territories_process import (
     create_geozones_fixtures
 )
 from udata.utils import faker
-from udata.tests.helpers import assert200, assert404, assert_redirects
+from udata.tests.helpers import assert200, assert404, assert_redirects, assert_equal_dates
 
 from .models import (
     DATACONNEXIONS_5_CANDIDATE, DATACONNEXIONS_6_CANDIDATE,
@@ -121,44 +123,257 @@ class GouvFrThemeTest:
         assert200(response)
 
 
-WP_ATOM_URL = 'http://somewhere.test/feed.atom'
+WP_FEED_URL = 'http://somewhere.test/feed'
 
 
-@pytest.mark.options(WP_ATOM_URL=WP_ATOM_URL)
+@pytest.mark.options(WP_ATOM_URL=WP_FEED_URL)
 class GouvFrHomeBlogTest:
     '''Ensure home page render with blog'''
     settings = GouvFrSettings
     modules = []
 
-    def test_render_home_with_blog(self, rmock, client):
+    @pytest.fixture
+    def home(self, mocker, client):
+        from . import theme
+
+        def home_client(blogpost):
+            mocker.patch.object(theme, 'get_blog_post', return_value=blogpost)
+            return client.get(url_for('site.home'))
+
+        return home_client
+
+    def test_render_home_with_blog_without_thumbnail(self, home):
         '''It should render the home page with the latest blog article'''
+        post = {
+            'title': faker.name(),
+            'link': faker.uri(),
+            'summary': faker.sentence(),
+            'date': faker.date_time(),
+        }
+        response = home(post)
+        assert200(response)
+        page = response.data.decode('utf8')
+        assert post['title'] in page
+        assert post['link'] in page
+        assert post['summary'] in page
+        assert 'blog-thumbnail' not in page
+
+    def test_render_home_with_blog_with_thumbnail(self, home):
+        '''It should render the home page with the latest blog article and its thumbnail'''
+        post = {
+            'title': faker.name(),
+            'link': faker.uri(),
+            'summary': faker.sentence(),
+            'date': faker.date_time(),
+            'image_url': faker.image_url(),
+        }
+        response = home(post)
+        assert200(response)
+        page = response.data.decode('utf8')
+        assert post['title'] in page
+        assert post['link'] in page
+        assert post['summary'] in page
+        assert post['image_url'] in page
+        assert 'blog-thumbnail' in page
+
+    def test_render_home_without_blogpost(self, home):
+        '''It should render the home page when blog post is missing'''
+        response = home(None)
+        assert200(response)
+        assert 'blog-container' not in response.data.decode('utf8')
+
+
+@pytest.mark.options(WP_ATOM_URL=WP_FEED_URL)
+class GetBlogPostMixin:
+    '''Ensure home page render with blog'''
+    settings = GouvFrSettings
+    mime = None
+
+    @pytest.fixture
+    def blogpost(self, app, rmock):
+        from .theme import get_blog_post
+
+        def fixture(feed):
+            if isinstance(feed, Exception):
+                rmock.get(WP_FEED_URL, exc=feed)
+            else:
+                rmock.get(WP_FEED_URL, text=feed, headers={'Content-Type': self.mime})
+            return get_blog_post('en')
+
+        return fixture
+
+
+    '''
+    <![CDATA[<p><img class="alignnone size-full wp-image-9750" src="https://www.etalab.gouv.fr/wp-content/uploads/2019/03/2019-03-01-cover-article-opendataday.png" alt="image de couverture pour l’article sur la journée mondiale des données ouvertes" width="1200" height="800" srcset="https://www.etalab.gouv.fr/wp-content/uploads/2019/03/2019-03-01-cover-article-opendataday.png 1200w, https://www.etalab.gouv.fr/wp-content/uploads/2019/03/2019-03-01-cover-article-opendataday-300x200.png 300w, https://www.etalab.gouv.fr/wp-content/uploads/2019/03/2019-03-01-cover-article-opendataday-768x512.png 768w, https://www.etalab.gouv.fr/wp-content/uploads/2019/03/2019-03-01-cover-article-opendataday-1024x683.png 1024w" sizes="(max-width: 1200px) 100vw, 1200px" /></p>
+    '''
+
+    def test_basic_blogpost(self, blogpost):
+        title = faker.sentence()
         post_url = faker.uri()
-        feed = AtomFeed('Some blog', feed_url=WP_ATOM_URL)
-        feed.add('Some post',
-                 '<div>Some content</div>',
-                 content_type='html',
-                 author=faker.name(),
-                 url=post_url,
-                 updated=faker.date_time(),
-                 published=faker.date_time())
-        rmock.get(WP_ATOM_URL, text=feed.to_string(),
-                  headers={'Content-Type': 'application/atom+xml'})
-        response = client.get(url_for('site.home'))
-        assert200(response)
-        assert 'Some post' in response.data.decode('utf8')
-        assert post_url in response.data.decode('utf8')
+        tz = pytz.timezone(faker.timezone())
+        publish_date = faker.date_time(tzinfo=tz)
+        content = faker.sentence()
+        html_content = '<div>{0}</div>'.format(content)
+        feed = self.feed('Some blog', title, html_content, post_url,
+                         published=publish_date,
+                         )
 
-    def test_render_home_if_blog_timeout(self, rmock, client):
-        '''It should render the home page when blog time out'''
-        rmock.get(WP_ATOM_URL, exc=requests.Timeout('Blog timed out'))
-        response = client.get(url_for('site.home'))
-        assert200(response)
+        post = blogpost(feed)
 
-    def test_render_home_if_blog_error(self, rmock, client):
-        '''It should render the home page when blog is not available'''
-        rmock.get(WP_ATOM_URL, exc=requests.ConnectionError('Error'))
-        response = client.get(url_for('site.home'))
-        assert200(response)
+        assert post['title'] == title
+        assert post['link'] == post_url
+        assert post['summary'] == content
+        assert_equal_dates(post['date'], publish_date)
+        assert 'image_url' not in post
+
+    def test_blogpost_with_summary(self, blogpost):
+        title = faker.sentence()
+        post_url = faker.uri()
+        summary = faker.sentence()
+        content = faker.sentence()
+        html_content = '<div>{0}</div>'.format(content)
+        tz = pytz.timezone(faker.timezone())
+        publish_date = faker.date_time(tzinfo=tz)
+        feed = self.feed('Some blog', title, html_content, post_url,
+                         published=publish_date,
+                         summary=summary
+                         )
+
+        post = blogpost(feed)
+        
+        assert post['title'] == title
+        assert post['link'] == post_url
+        assert post['summary'] == summary
+        assert_equal_dates(post['date'], publish_date)
+        assert 'image_url' not in post
+
+    def test_blogpost_with_first_image_as_thumbnail(self, blogpost):
+        title = faker.sentence()
+        post_url = faker.uri()
+        image_url = faker.image_url()
+        summary = faker.sentence()
+        tz = pytz.timezone(faker.timezone())
+        publish_date = faker.date_time(tzinfo=tz)
+        content = '<p><img class="whatever" src="{0}" /> {1}</p>'.format(image_url, summary)
+        feed = self.feed('Some blog', title, content, post_url,
+                         published=publish_date)
+        
+        post = blogpost(feed)
+
+        assert post['title'] == title
+        assert post['link'] == post_url
+        assert post['summary'] == summary
+        assert_equal_dates(post['date'], publish_date)
+        assert post['image_url'] == image_url
+
+    def test_blogpost_with_first_image_as_thumbnail_and_summary(self, blogpost):
+        title = faker.sentence()
+        post_url = faker.uri()
+        image_url = faker.image_url()
+        summary = faker.sentence()
+        tz = pytz.timezone(faker.timezone())
+        publish_date = faker.date_time(tzinfo=tz)
+        content = '<p><img class="whatever" src="{0}" /> Whatever whatever</p>'.format(image_url)
+        feed = self.feed('Some blog', title, content, post_url,
+                         published=publish_date,
+                         summary=summary)
+        
+        post = blogpost(feed)
+
+        assert post['title'] == title
+        assert post['link'] == post_url
+        assert post['summary'] == summary
+        assert_equal_dates(post['date'], publish_date)
+        assert post['image_url'] == image_url
+
+    # def test_render_home_with_blog_and_thumbnail_as_enclosure(self, rmock, client):
+    #     '''It should render the home page with the latest blog article'''
+    #     post_url = faker.uri()
+    #     feed = AtomFeed('Some blog', feed_url=WP_ATOM_URL)
+    #     feed.add('Some post',
+    #              '<div>Some content</div>',
+    #              content_type='html',
+    #              author=faker.name(),
+    #              url=post_url,
+    #              updated=faker.date_time(),
+    #              published=faker.date_time())
+    #     rmock.get(WP_ATOM_URL, text=feed.to_string(),
+    #               headers={'Content-Type': 'application/atom+xml'})
+    #     response = client.get(url_for('site.home'))
+    #     assert200(response)
+    #     assert 'Some post' in response.data.decode('utf8')
+    #     assert post_url in response.data.decode('utf8')
+
+    # def test_render_home_with_blog_and_thumbnail_as_srcset(self, rmock, client):
+    #     '''It should render the home page with the latest blog article'''
+    #     post_url = faker.uri()
+    #     feed = AtomFeed('Some blog', feed_url=WP_ATOM_URL)
+    #     feed.add('Some post',
+    #              '<div>Some content</div>',
+    #              content_type='html',
+    #              author=faker.name(),
+    #              url=post_url,
+    #              updated=faker.date_time(),
+    #              published=faker.date_time())
+    #     rmock.get(WP_ATOM_URL, text=feed.to_string(),
+    #               headers={'Content-Type': 'application/atom+xml'})
+    #     response = client.get(url_for('site.home'))
+    #     assert200(response)
+    #     assert 'Some post' in response.data.decode('utf8')
+    #     assert post_url in response.data.decode('utf8')
+
+    def test_render_home_if_blog_timeout(self, blogpost):
+        '''It should not fail when blog time out'''
+        exc = requests.Timeout('Blog timed out')
+        assert blogpost(exc) is None
+
+    def test_render_home_if_blog_error(self, blogpost):
+        '''It should not fail when blog is not available'''
+        exc = requests.ConnectionError('Error')
+        assert blogpost(exc) is None
+
+
+class GetBlogPostAtomTest(GetBlogPostMixin):
+    mime = 'application/atom+xml'
+
+    def feed(self, feed_title, title, content, url, published=None, summary=None):
+        feed = AtomFeed(feed_title, feed_url=WP_FEED_URL)
+        tz = pytz.timezone(faker.timezone())
+        published = published or faker.date_time(tzinfo=tz)
+        kwargs = {
+            'content_type': 'html',
+            'author': faker.name(),
+            'url': url,
+            'updated': faker.date_time_between(start_date=published, tzinfo=tz),
+            'published': published
+        }
+        if summary:
+            kwargs['summary'] = summary
+        feed.add(title, content, **kwargs)
+        return feed.to_string()
+
+class GetBlogPostRssTest(GetBlogPostMixin):
+    mime = 'application/rss+xml'
+
+    def feed(self, feed_title, title, content, url, published=None, summary=None):
+        feed = FeedGenerator()
+        feed.title(feed_title)
+        feed.description(faker.sentence())
+        feed.link({'href': WP_FEED_URL})
+
+        entry = feed.add_entry()
+        entry.title(title)
+        entry.link({'href': url})
+        entry.author(name=faker.name())
+        entry.content(content, type="cdata")
+        if summary:
+            entry.description(summary)
+        tz = pytz.timezone(faker.timezone())
+        published = published or faker.date_time(tzinfo=tz)
+        entry.published(published)
+        entry.updated(faker.date_time_between(start_date=published, tzinfo=tz))
+
+        return feed.rss_str().decode('utf8')
 
 
 DISCOURSE_URL = 'http://somewhere.test/discourse'

--- a/udata_gouvfr/tests.py
+++ b/udata_gouvfr/tests.py
@@ -235,7 +235,7 @@ class GetBlogPostMixin:
                          summary=summary)
 
         post = blogpost(feed)
-        
+
         assert post['title'] == title
         assert post['link'] == post_url
         assert post['summary'] == summary
@@ -243,7 +243,6 @@ class GetBlogPostMixin:
         assert 'image_url' not in post
         assert 'srcset' not in post
         assert 'sizes' not in post
-        
 
     def test_blogpost_with_first_image_as_thumbnail(self, blogpost):
         title = faker.sentence()
@@ -255,7 +254,7 @@ class GetBlogPostMixin:
         content = '<p><img class="whatever" src="{0}" /> {1}</p>'.format(image_url, summary)
         feed = self.feed('Some blog', title, content, post_url,
                          published=publish_date)
-        
+
         post = blogpost(feed)
 
         assert post['title'] == title
@@ -277,7 +276,7 @@ class GetBlogPostMixin:
         feed = self.feed('Some blog', title, content, post_url,
                          published=publish_date,
                          summary=summary)
-        
+
         post = blogpost(feed)
 
         assert post['title'] == title
@@ -307,11 +306,11 @@ class GetBlogPostMixin:
         )
         sizes = "(max-width: 1200px) 100vw, 1200px"
         content = tpl.format(image_url, srcset, sizes)
-        
+
         feed = self.feed('Some blog', title, content, post_url,
                          published=publish_date,
                          summary=summary)
-        
+
         post = blogpost(feed)
 
         assert post['title'] == title
@@ -409,6 +408,7 @@ class GetBlogPostAtomTest(GetBlogPostMixin):
             out = out.replace('<feed', '<feed xmlns:media="http://search.yahoo.com/mrss/"')
             out = out.replace('</entry>', '{0}</entry>'.format(el))
         return out
+
 
 class GetBlogPostRssTest(GetBlogPostMixin):
     mime = 'application/rss+xml'

--- a/udata_gouvfr/tests.py
+++ b/udata_gouvfr/tests.py
@@ -646,6 +646,7 @@ class TerritoriesSettings(GouvFrSettings):
     HANDLED_LEVELS = ('fr:commune', 'fr:departement', 'fr:region')
 
 
+@pytest.mark.usefixtures('clean_db')
 class TerritoriesTest:
     settings = TerritoriesSettings
     modules = []
@@ -694,6 +695,7 @@ class TerritoriesTest:
             assert expected.format(dataset=dataset) in data
 
 
+@pytest.mark.usefixtures('clean_db')
 class OEmbedsTerritoryAPITest:
     settings = TerritoriesSettings
     modules = []
@@ -811,6 +813,7 @@ class OEmbedsTerritoryAPITest:
                     in html)
 
 
+@pytest.mark.usefixtures('clean_db')
 class SpatialTerritoriesApiTest:
     settings = TerritoriesSettings
     modules = []
@@ -922,6 +925,7 @@ class SitemapTest:
             assert '<loc>{url}</loc>'.format(url=url) in response.data
 
 
+@pytest.mark.usefixtures('clean_db')
 class SitemapTerritoriesTest:
     settings = TerritoriesSettings
     modules = []

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -26,10 +26,10 @@ RE_POST_IMG = re.compile(
         sizes="(?P<sizes>.+?)"
     )\s*)+ .*?/>
     ''',
-    re.I|re.X|re.S
+    re.I | re.X | re.S
 )
 
-RE_STRIP_TAGS = re.compile(r'</?(img|br|p|div|ul|li|ol)[^<>]*?>', re.I|re.M)
+RE_STRIP_TAGS = re.compile(r'</?(img|br|p|div|ul|li|ol)[^<>]*?>', re.I | re.M)
 
 # Add some html5 allowed attributes
 EXTRA_ATTRIBUTES = ('srcset', 'sizes')

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -163,10 +163,13 @@
             </div>
 
             <div class="row gray">
-                <div class="col-xs-12 col-sm-4 photo">
+                {% set has_thumbnail = blogpost.image_url is defined %}
+                {% if has_thumbnail %}
+                <div class="col-xs-12 col-sm-4 photo blog-thumbnail">
                     <img src="{{ blogpost.image_url|safe }}" alt="{{ blogpost.title|safe }}">
                 </div>
-                <div class="col-xs-12 col-sm-8 body">
+                {% endif  %}
+                <div class="col-xs-12 {% if has_thumbnail %}col-sm-8 {% endif %}body">
                     <span class="post-date">{{blogpost.date|dateformat('long')|title}}</span>
                     <h4>
                         <a href="{{ blogpost.link }}"


### PR DESCRIPTION
This PR improves the Atom/RSS parsing and fixes multiple issues:
- parses both Atom and RSS 2.0
- supports missing thumbnail
- supports thumbnail from first image
- supports `srcset`/`sizes` attributes on `img` tags
- supports thumbnail as enclosure
- supports thumbnail as `media:rss` node

## Possible improvements
- this could be extracted as a themable last post from RSS/Atom widget into its own extensions
- for coherence, `WP_ATOM_URL` should be name `FEED_URL` or something more generic
- image size when available could be used to determinate the best image to display
