### PR TITLE
change le tampon de certification de place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Minor edits on SPD [#406](https://github.com/etalab/udata-gouvfr/pull/406)
+- Change certification visual location in cards [#407](https://github.com/etalab/udata-gouvfr/pull/407)
 
 ## 1.6.7 (2019-05-23)
 

--- a/theme/less/gouvfr/cards.less
+++ b/theme/less/gouvfr/cards.less
@@ -57,4 +57,8 @@
             border-color: @user-color;
         }
     }
+
+    img.certified {
+        left: 39px;
+    }
 }


### PR DESCRIPTION
Il est du côté droit sur l'ensemble du site sauf dans les cartes.

## Avant

![image](https://user-images.githubusercontent.com/27315/58414002-6af02800-807a-11e9-9a89-87f22621a617.png)

## Après

![image](https://user-images.githubusercontent.com/27315/58413981-5a3fb200-807a-11e9-98c2-2bda6c40f604.png)
