### PR TITLE
utilise `block related` pour ne rien mettre en pied de page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Switch removal of related tags in a topic page to a proper `related` jinja tag [#408](https://github.com/etalab/udata-gouvfr/pull/408)
 
 ## 1.6.8 (2019-05-29)
 

--- a/udata_gouvfr/theme/templates/topic/display_base.html
+++ b/udata_gouvfr/theme/templates/topic/display_base.html
@@ -3,7 +3,4 @@
 {% block subnav %}{% include theme('topic/subnav.html') %}{% endblock %}
 
 
-{% block content %}
-{{ breadcrumb(self) }}
-{% block main_content %}{% endblock %}
-{% endblock %}
+{% block related %}{% endblock %}


### PR DESCRIPTION
see also: https://github.com/opendatateam/udata/pull/2171