### PR TITLE
Add SPDX short identifier for licence Ouverte 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ajout de l'identifiant SPDX pour la licence Ouverte 2.0 [#437](https://github.com/etalab/udata-gouvfr/pull/437)
 
 ## 1.6.12 (2019-09-11)
 

--- a/udata_gouvfr/templates/licences.html
+++ b/udata_gouvfr/templates/licences.html
@@ -71,7 +71,7 @@
       <li>
           <a href="https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf">
           Licence Ouverte version 2.0
-          <span class="pull-right">en cours</span></a>
+          <span class="badge pull-right">etalab-2.0</span></a>
       </li>
   </ul>
 


### PR DESCRIPTION
The inclusion of the licence Ouverte 2.0 in the SPDX list
has been discussed here:

https://github.com/spdx/license-list-XML/issues/923