### PR TITLE
include external widget from recherche.etalab.studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Ajout du _flag_ "recherche" pour activer le _widget_ d'experimentation de recherche [#466](https://github.com/etalab/udata-gouvfr/pull/466/commits/9c42b5aa8e6e0e37f471a32182196b989bc41a68)
 
 ## 1.6.13 (2019-12-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Current (in progress)
+## 1.6.13 (2019-12-13)
 
 - Ajout de l'identifiant SPDX pour la licence Ouverte 2.0 [#437](https://github.com/etalab/udata-gouvfr/pull/437)
 - Lien vers la doc d'API externe dans le footer [#438](https://github.com/etalab/udata-gouvfr/pull/438)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Current (in progress)
+
+- Nothing yet
+
 ## 1.6.13 (2019-12-13)
 
 - Ajout de l'identifiant SPDX pour la licence Ouverte 2.0 [#437](https://github.com/etalab/udata-gouvfr/pull/437)

--- a/udata_gouvfr/__init__.py
+++ b/udata_gouvfr/__init__.py
@@ -4,5 +4,5 @@ uData customizations for Data.gouv.fr
 '''
 from __future__ import unicode_literals
 
-__version__ = '1.6.13'
+__version__ = '1.6.14.dev'
 __description__ = 'uData customizations for Data.gouv.fr'

--- a/udata_gouvfr/__init__.py
+++ b/udata_gouvfr/__init__.py
@@ -4,5 +4,5 @@ uData customizations for Data.gouv.fr
 '''
 from __future__ import unicode_literals
 
-__version__ = '1.6.13.dev'
+__version__ = '1.6.13'
 __description__ = 'uData customizations for Data.gouv.fr'

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -199,4 +199,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {% if request.args.get('flag') == 'recherche' -%}
+        <script src="https://recherche.etalab.studio/js/widget.js"></script>
+    {%- endif %}
 {% endblock %}


### PR DESCRIPTION
C'est ce que j'ai trouvé de plus minimaliste et moins intrusif.

N'ayant pas encore réinstallé udata, c'est non testé par contre 🍿 