### PR TITLE
Add static /pages/* from md in github repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add static /pages/* from md in github repo [#483](https://github.com/etalab/udata-gouvfr/pull/483)
 
 ## 2.1.3 (2020-06-16)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,3 @@
 udata>=2.0.0
 feedparser==5.2.1
+python-frontmatter==0.5.0

--- a/udata_gouvfr/settings.py
+++ b/udata_gouvfr/settings.py
@@ -1,0 +1,11 @@
+"""
+Default settings for udata-gouvfr
+"""
+
+# Frontend banner parameters
+BANNER_ACTIVATED = False
+BANNER_HTML_FILENAME = ''
+
+# Static pages from github repo
+PAGES_GH_REPO_NAME = 'etalab/datagouvfr-pages'
+PAGES_REPO_BRANCH = 'master'

--- a/udata_gouvfr/templates/page.html
+++ b/udata_gouvfr/templates/page.html
@@ -1,0 +1,22 @@
+{% extends theme("base.html") %}
+
+<!-- TODO: -->
+{% set meta = {
+    'title': _('Terms'),
+    'description': _('Terms'),
+    'keywords': [
+        'terms', _('terms'),
+    ],
+} %}
+
+{% block content %}
+<section class="content">
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12">
+                {{ content|markdown }}
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/udata_gouvfr/templates/page.html
+++ b/udata_gouvfr/templates/page.html
@@ -1,12 +1,9 @@
 {% extends theme("base.html") %}
 
-<!-- TODO: -->
 {% set meta = {
-    'title': _('Terms'),
-    'description': _('Terms'),
-    'keywords': [
-        'terms', _('terms'),
-    ],
+    'title': page.title or '',
+    'description': page.description or '',
+    'keywords': page.keywords or [],
 } %}
 
 {% block content %}
@@ -14,7 +11,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                {{ content|markdown }}
+                {{ page.content|markdown }}
             </div>
         </div>
     </div>

--- a/udata_gouvfr/templates/page.html
+++ b/udata_gouvfr/templates/page.html
@@ -1,4 +1,4 @@
-{% extends theme("base.html") %}
+{% extends theme('base.html') %}
 
 {% set meta = {
     'title': page.title or '',
@@ -6,38 +6,67 @@
     'keywords': page.keywords or [],
 } %}
 
+{% set bundle = 'post' %}
+
+{% set body_class = 'post-display' %}
+
 {% block content %}
-<section class="content">
-    <div class="container">
+<section class="post-section default">
+    <div class="container post-container">
         <div class="row">
-            <div class="col-xs-12">
-                {{ page.content|markdown }}
+
+            <div class="{% if datasets or reuses %}col-sm-8 smaller{% else %}col-xs-12{% endif %}">
+
+                <div class="post-body">
+                    {{ page.content|markdown }}
+                </div>
+
+                {# button bar #}
+                <div class="row main-toolbar"><div class="col-xs-12">
+                    <div class="btn-toolbar pull-right">
+                        <div class="btn-group btn-group-sm">
+                            <a href="{{ gh_url }}" class="btn btn-success">
+                                <span class="fa fa-pencil"></span>
+                                {{ _('Proposer une modification') }}
+                            </a>
+                        </div>
+                    </div>
+                </div></div>
+                {# end button bar #}
+
             </div>
-            {% if datasets %}
-            <h2>Jeux de données</h2>
-            <div class="row">
-                <ul class="card-list">
-                    {% for dataset in datasets %}
-                    <li class="col-md-4 col-sm-6">
-                    {% include theme('dataset/card.html') %}
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
-            {% endif %}
-            {% if reuses %}
-            <h2>Réutilisations</h2>
-            <div class="row">
-                <ul class="card-list">
+            {# end left column #}
+
+            {% if datasets or reuses %}
+            {# Right sidebar #}
+            <aside class="col-sm-4">
+
+                {# Reuses list #}
+                {% if reuses %}
+                <h3>{{ ngettext('Associated reuse', 'Associated reuses', reuses|length) }}</h3>
+                <div class="card-list">
                     {% for reuse in reuses %}
-                    <li class="col-md-4 col-sm-6">
                     {% include theme('reuse/card.html') %}
-                    </li>
                     {% endfor %}
-                </ul>
-            </div>
+                </div>
+                {% endif %}
+                {# end reuses list #}
+
+                {# Datasets list #}
+                {% if datasets %}
+                <h3>{{ ngettext('Associated dataset', 'Associated datasets', datasets|length) }}</h3>
+                <div class="card-list">
+                    {% for dataset in datasets %}
+                    {% include theme('dataset/card.html') %}
+                    {% endfor %}
+                </div>
+                {% endif %}
+                {# end post list #}
+
+            </aside>
             {% endif %}
         </div>
+
     </div>
 </section>
 {% endblock %}

--- a/udata_gouvfr/templates/page.html
+++ b/udata_gouvfr/templates/page.html
@@ -13,6 +13,30 @@
             <div class="col-xs-12">
                 {{ page.content|markdown }}
             </div>
+            {% if datasets %}
+            <h2>Jeux de données</h2>
+            <div class="row">
+                <ul class="card-list">
+                    {% for dataset in datasets %}
+                    <li class="col-md-4 col-sm-6">
+                    {% include theme('dataset/card.html') %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+            {% if reuses %}
+            <h2>Réutilisations</h2>
+            <div class="row">
+                <ul class="card-list">
+                    {% for reuse in reuses %}
+                    <li class="col-md-4 col-sm-6">
+                    {% include theme('reuse/card.html') %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
         </div>
     </div>
 </section>

--- a/udata_gouvfr/tests/test_static_pages.py
+++ b/udata_gouvfr/tests/test_static_pages.py
@@ -1,0 +1,25 @@
+import pytest
+
+from flask import url_for
+
+from udata_gouvfr.views import get_pages_gh_urls
+from .tests import GouvFrSettings
+
+
+@pytest.mark.usefixtures('clean_db')
+class StaticPagesTest:
+    settings = GouvFrSettings
+    modules = []
+
+    def test_page_does_not_exist(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('doesnotexist')
+        rmock.get(raw_url, status_code=404)
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        assert response.status_code == 404
+
+    def test_page(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('test')
+        rmock.get(raw_url, text="""#test""")
+        response = client.get(url_for('gouvfr.show_page', slug='test'))
+        assert response.status_code == 200
+        assert b'<h1>test</h1>' in response.data

--- a/udata_gouvfr/tests/tests.py
+++ b/udata_gouvfr/tests/tests.py
@@ -25,11 +25,11 @@ from udata.tests.features.territories.test_territories_process import (
 from udata.utils import faker
 from udata.tests.helpers import assert200, assert404, assert_redirects, assert_equal_dates
 
-from .models import (
+from udata_gouvfr.models import (
     DATACONNEXIONS_5_CANDIDATE, DATACONNEXIONS_6_CANDIDATE,
     TERRITORY_DATASETS, OPENFIELD16, SPD
 )
-from .views import DATACONNEXIONS_5_CATEGORIES, DATACONNEXIONS_6_CATEGORIES
+from udata_gouvfr.views import DATACONNEXIONS_5_CATEGORIES, DATACONNEXIONS_6_CATEGORIES
 
 
 class GouvFrSettings(Testing):
@@ -132,7 +132,7 @@ class GouvFrHomeBlogTest:
 
     @pytest.fixture
     def home(self, mocker, client):
-        from . import theme
+        from udata_gouvfr import theme
 
         def home_client(blogpost):
             mocker.patch.object(theme, 'get_blog_post', return_value=blogpost)
@@ -189,7 +189,7 @@ class GetBlogPostMixin:
 
     @pytest.fixture
     def blogpost(self, app, rmock):
-        from .theme import get_blog_post
+        from udata_gouvfr.theme import get_blog_post
 
         def fixture(feed):
             if isinstance(feed, Exception):

--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -1,3 +1,4 @@
+import frontmatter
 import requests
 
 from flask import url_for, redirect, abort, current_app
@@ -67,7 +68,8 @@ def get_page_content(slug):
 @blueprint.route('/pages/<slug>')
 def show_page(slug):
     content = get_page_content(slug)
-    return theme.render('page.html', content=content)
+    page = frontmatter.loads(content)
+    return theme.render('page.html', page=page)
 
 
 @blueprint.route('/dataconnexions/')

--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -65,11 +65,23 @@ def get_page_content(slug):
     return response.text
 
 
+def get_object(model, id_or_slug):
+    objects = getattr(model, 'objects')
+    obj = objects.filter(slug=id_or_slug).first()
+    if not obj:
+        obj = objects.filter(id=id_or_slug).first()
+    return obj
+
+
 @blueprint.route('/pages/<slug>')
 def show_page(slug):
     content = get_page_content(slug)
     page = frontmatter.loads(content)
-    return theme.render('page.html', page=page)
+    reuses = [get_object(Reuse, r) for r in page.get('reuses', [])]
+    datasets = [get_object(Dataset, d) for d in page.get('datasets', [])]
+    reuses = [r for r in reuses if r is not None]
+    datasets = [d for d in datasets if d is not None]
+    return theme.render('page.html', page=page, reuses=reuses, datasets=datasets)
 
 
 @blueprint.route('/dataconnexions/')

--- a/udata_gouvfr/views.py
+++ b/udata_gouvfr/views.py
@@ -65,7 +65,7 @@ def get_page_content(slug):
 
 
 @blueprint.route('/pages/<slug>')
-def show_pages(slug):
+def show_page(slug):
     content = get_page_content(slug)
     return theme.render('page.html', content=content)
 


### PR DESCRIPTION
## Description

This PR allows us to create, modify and crowdsource some static pages content on a GitHub repo. Every file named `pages/<slug>.md` in the repo will be available on `data.gouv.fr/pages/<slug>`. At the time being, the layout is similar to a post, eg https://www.data.gouv.fr/fr/posts/suivi-des-sorties-mai-2020/. It's possible to add linked datasets and reuses through frontmatter header:

```
---
title: Blogging Like a Hacker
keywords:
  - test
  - k2
  - anapurna
description: yeah, described
reuses:
  - 5eb2c6d45adcbd021d7b6cd5
datasets:
  - depenses-d-assurance-maladie-hors-prestations-hospitalieres-donnees-nationales
---
```

## TODO

- [x] handle frontmatter parsing for metadata
- [x] add descriptions and reuses ids from front matter  
- [ ] ~parse dataset and reuse cards from markdown links?~ -> v2 ;-)
- [x] layout: maybe like post w/ columns for a first version
- [x] handle settings in a new `settings.py` dedicated to `udata-gouvfr` 
- [x] tests

## Example

Markdown on GitHub: https://github.com/abulte/datagouvfr-pages/blob/master/pages/keywords.md

<img width="995" alt="Capture d'écran 2020-06-22 09 11 32" src="https://user-images.githubusercontent.com/119625/85258830-6312db00-b468-11ea-8303-899961e794fe.png">