### PR TITLE
Build footer menu from datagouvfr-pages

### DIFF
--- a/udata_gouvfr/pages/utils.py
+++ b/udata_gouvfr/pages/utils.py
@@ -7,31 +7,53 @@ from mongoengine.errors import ValidationError
 
 from udata.app import cache
 
-CACHE_DURATION = 300  # in seconds
+PAGE_CACHE_DURATION = 60 * 5  # in seconds
+MENU_CACHE_DURATION = 60 * 60  # in seconds
 log = logging.getLogger(__name__)
 
 
-@cache.cached(CACHE_DURATION)
-def get_menu_list(menu):
-    """Build a menu list from github repo"""
+def get_menu_gh_url():
     repo = current_app.config.get('PAGES_GH_REPO_NAME')
     if not repo:
-        return []
+        return
     branch = current_app.config.get('PAGES_REPO_BRANCH', 'master')
-    url = f'https://api.github.com/repos/{repo}/contents/pages?ref={branch}'
-    r = requests.get(url, timeout=5)
-    if not r.ok:
-        log.error(f'Error ({r.status_code}) while fetching pages list')
+    return f'https://api.github.com/repos/{repo}/contents/pages?ref={branch}'
+
+
+@cache.cached(MENU_CACHE_DURATION)
+def get_menu_list(menu):
+    """
+    Build a menu list from github repo
+
+    This has a double layer of cache:
+    - @cache.cached decorator w/ short lived cache for normal operations
+    - a long terme cache w/o timeout to be able to always render some content
+    """
+    cache_key = f'pages-menu-{menu}'
+    url = get_menu_gh_url()
+    if not url:
+        log.warning('No url set for pages')
         return []
+    try:
+        r = requests.get(url, timeout=5)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        log.error(f'Error ({e}) while fetching pages list')
+        return cache.get(cache_key) or []
     pages = []
     for page in r.json():
         if page['name'].endswith('.md'):
-            r = requests.get(page['download_url'])
+            try:
+                r = requests.get(page['download_url'], timeout=5)
+            except requests.exceptions.RequestException as e:
+                log.error(f'Error ({e}) while fetching page content for {page["name"]}')
+                return cache.get(cache_key) or []
             data = frontmatter.loads(r.text)
             menu_list = data.get('menu', [])
             if menu in menu_list:
                 page_url = url_for('gouvfr.show_page', slug=page['name'][:-3], _external=True)
                 pages.append((data['title'], page_url))
+    cache.set(cache_key, pages)
     return pages
 
 
@@ -45,17 +67,34 @@ def get_pages_gh_urls(slug):
     return raw_url, gh_url
 
 
-@cache.cached(CACHE_DURATION)
+@cache.cached(PAGE_CACHE_DURATION)
 def get_page_content(slug):
+    '''
+    Get a page content from gh repo (md).
+
+    This has a double layer of cache:
+    - @cache.cached decorator w/ short lived cache for normal operations
+    - a long terme cache w/o timeout to be able to always render some content
+    '''
+    cache_key = f'pages-content-{slug}'
     raw_url, gh_url = get_pages_gh_urls(slug)
-    # We let the error appear because:
-    # - we dont want to cache false responses
-    # - this is only visible on static page
-    response = requests.get(raw_url, timeout=5)
-    if response.status_code == 404:
-        abort(404)
-    response.raise_for_status()
-    return response.text, gh_url
+    try:
+        response = requests.get(raw_url, timeout=5)
+        # do not cache 404 and forward status code
+        if response.status_code == 404:
+            abort(404)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        log.exception(f'Error while getting {slug} page from gh: {e}')
+        content = cache.get(cache_key)
+    else:
+        content = response.text
+        cache.set(cache_key, content)
+    # no cached version or no content from gh
+    if not content:
+        log.error(f'No content found inc. from cache for page {slug}')
+        abort(503)
+    return content, gh_url
 
 
 def get_object(model, id_or_slug):

--- a/udata_gouvfr/pages/utils.py
+++ b/udata_gouvfr/pages/utils.py
@@ -21,7 +21,7 @@ def get_menu_gh_url():
     return f'https://api.github.com/repos/{repo}/contents/pages?ref={branch}'
 
 
-@cache.cached(MENU_CACHE_DURATION)
+@cache.memoize(MENU_CACHE_DURATION)
 def get_menu_list(menu):
     """
     Build a menu list from github repo
@@ -68,7 +68,7 @@ def get_pages_gh_urls(slug):
     return raw_url, gh_url
 
 
-@cache.cached(PAGE_CACHE_DURATION)
+@cache.memoize(PAGE_CACHE_DURATION)
 def get_page_content(slug):
     '''
     Get a page content from gh repo (md).

--- a/udata_gouvfr/pages/utils.py
+++ b/udata_gouvfr/pages/utils.py
@@ -1,0 +1,69 @@
+import frontmatter
+import logging
+import requests
+
+from flask import current_app, abort, url_for
+from mongoengine.errors import ValidationError
+
+from udata.app import cache, nav
+
+CACHE_DURATION = 300  # in seconds
+log = logging.getLogger(__name__)
+
+
+@cache.cached(CACHE_DURATION)
+def get_menu_list(menu):
+    """Build a menu list from github repo"""
+    repo = current_app.config.get('PAGES_GH_REPO_NAME')
+    if not repo:
+        return []
+    branch = current_app.config.get('PAGES_REPO_BRANCH', 'master')
+    url = f'https://api.github.com/repos/{repo}/contents/pages?ref={branch}'
+    r = requests.get(url, timeout=5)
+    if not r.ok:
+        log.error(f'Error ({r.status_code}) while fetching pages list')
+        return []
+    pages = []
+    for page in r.json():
+        if page['name'].endswith('.md'):
+            r = requests.get(page['download_url'])
+            data = frontmatter.loads(r.text)
+            menu_list = data.get('menu', [])
+            if menu in menu_list:
+                page_url = url_for('gouvfr.show_page', slug=page['name'][:-3], _external=True)
+                pages.append(nav.Item(data['title'], None, url=page_url))
+    return pages
+
+
+def get_pages_gh_urls(slug):
+    repo = current_app.config.get('PAGES_GH_REPO_NAME')
+    if not repo:
+        abort(404)
+    branch = current_app.config.get('PAGES_REPO_BRANCH', 'master')
+    raw_url = f'https://raw.githubusercontent.com/{repo}/{branch}/pages/{slug}.md'
+    gh_url = f'https://github.com/{repo}/blob/{branch}/pages/{slug}.md'
+    return raw_url, gh_url
+
+
+@cache.cached(CACHE_DURATION)
+def get_page_content(slug):
+    raw_url, gh_url = get_pages_gh_urls(slug)
+    # We let the error appear because:
+    # - we dont want to cache false responses
+    # - this is only visible on static page
+    response = requests.get(raw_url, timeout=5)
+    if response.status_code == 404:
+        abort(404)
+    response.raise_for_status()
+    return response.text, gh_url
+
+
+def get_object(model, id_or_slug):
+    objects = getattr(model, 'objects')
+    obj = objects.filter(slug=id_or_slug).first()
+    if not obj:
+        try:
+            obj = objects.filter(id=id_or_slug).first()
+        except ValidationError:
+            pass
+    return obj

--- a/udata_gouvfr/pages/utils.py
+++ b/udata_gouvfr/pages/utils.py
@@ -7,9 +7,10 @@ from mongoengine.errors import ValidationError
 
 from udata.app import cache
 
+log = logging.getLogger(__name__)
+
 PAGE_CACHE_DURATION = 60 * 5  # in seconds
 MENU_CACHE_DURATION = 60 * 60  # in seconds
-log = logging.getLogger(__name__)
 
 
 def get_menu_gh_url():

--- a/udata_gouvfr/pages/utils.py
+++ b/udata_gouvfr/pages/utils.py
@@ -5,7 +5,7 @@ import requests
 from flask import current_app, abort, url_for
 from mongoengine.errors import ValidationError
 
-from udata.app import cache, nav
+from udata.app import cache
 
 CACHE_DURATION = 300  # in seconds
 log = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ def get_menu_list(menu):
             menu_list = data.get('menu', [])
             if menu in menu_list:
                 page_url = url_for('gouvfr.show_page', slug=page['name'][:-3], _external=True)
-                pages.append(nav.Item(data['title'], None, url=page_url))
+                pages.append((data['title'], page_url))
     return pages
 
 

--- a/udata_gouvfr/tests/test_static_pages.py
+++ b/udata_gouvfr/tests/test_static_pages.py
@@ -49,6 +49,13 @@ class StaticPagesTest:
         assert b'dummy_from_cache' in response.data
         assert rmock.call_count == 2
 
+    def test_page_error_empty_cache(self, client, rmock, mocker):
+        mocker.patch.object(cache, 'get', return_value=None)
+        raw_url, gh_url = get_pages_gh_urls('cache1')
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert response.status_code == 503
+
     def test_page(self, client, rmock):
         raw_url, gh_url = get_pages_gh_urls('test')
         rmock.get(raw_url, text="""#test""")
@@ -85,6 +92,14 @@ menu:
         assert rmock.call_count == 1
         assert len(menu) == 1
         assert menu[0] == 'dummy_from_cache'
+
+    def test_menu_empty_cache(self, mocker, rmock):
+        url = get_menu_gh_url()
+        mocker.patch.object(cache, 'get', return_value=None)
+        rmock.get(url, status_code=500)
+        menu = get_menu_list('footer')
+        assert rmock.call_count == 1
+        assert len(menu) == 0
 
     def test_menu_cache_timeout(self, mocker, rmock):
         url = get_menu_gh_url()

--- a/udata_gouvfr/tests/test_static_pages.py
+++ b/udata_gouvfr/tests/test_static_pages.py
@@ -1,8 +1,14 @@
 import pytest
+import requests
 
 from flask import url_for
 
-from udata_gouvfr.views import get_pages_gh_urls
+from udata.app import cache
+from udata_gouvfr.pages.utils import (
+    get_pages_gh_urls,
+    get_menu_list,
+    get_menu_gh_url,
+)
 from .tests import GouvFrSettings
 
 
@@ -17,9 +23,85 @@ class StaticPagesTest:
         response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
         assert response.status_code == 404
 
+    def test_page_error_no_cache(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('doesnotexist')
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        assert response.status_code == 503
+
+    def test_page_timeout_no_cache(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('doesnotexist')
+        rmock.get(raw_url, exc=requests.exceptions.ConnectTimeout)
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        assert response.status_code == 503
+
+    def test_page_error_w_cache(self, client, rmock, mocker):
+        cache_mock_set = mocker.patch.object(cache, 'set')
+        mocker.patch.object(cache, 'get', return_value='dummy_from_cache')
+        raw_url, gh_url = get_pages_gh_urls('cache1')
+        # fill cache
+        rmock.get(raw_url, text="""#test""")
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert cache_mock_set.called
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert response.status_code == 200
+        assert b'dummy_from_cache' in response.data
+        assert rmock.call_count == 2
+
     def test_page(self, client, rmock):
         raw_url, gh_url = get_pages_gh_urls('test')
         rmock.get(raw_url, text="""#test""")
         response = client.get(url_for('gouvfr.show_page', slug='test'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
+
+    def test_menu(self, client, rmock, mocker):
+        cache_mock_set = mocker.patch.object(cache, 'set')
+        url = get_menu_gh_url()
+        rmock.get(url, json=[{
+            'name': 'test.md',
+            'download_url': 'https://dl.me/page'
+        }])
+        rmock.get('https://dl.me/page', text="""---
+title: test
+menu:
+    - footer
+---
+# test
+""")
+        menu = get_menu_list('footer')
+        assert cache_mock_set.called
+        assert rmock.call_count == 2
+        assert len(menu) == 1
+        assert menu[0][0] == 'test'
+        assert menu[0][1] == url_for('gouvfr.show_page', slug='test', _external=True)
+
+    def test_menu_cache_error(self, mocker, rmock):
+        url = get_menu_gh_url()
+        mocker.patch.object(cache, 'get', return_value=['dummy_from_cache'])
+        rmock.get(url, status_code=500)
+        menu = get_menu_list('footer')
+        assert rmock.call_count == 1
+        assert len(menu) == 1
+        assert menu[0] == 'dummy_from_cache'
+
+    def test_menu_cache_timeout(self, mocker, rmock):
+        url = get_menu_gh_url()
+        mocker.patch.object(cache, 'get', return_value=['dummy_from_cache'])
+
+        # timeout when fetching list
+        rmock.get(url, exc=requests.exceptions.ConnectTimeout)
+        menu = get_menu_list('footer')
+        assert len(menu) == 1
+        assert menu[0] == 'dummy_from_cache'
+
+        # timeout when fetching page content
+        rmock.get(url, json=[{
+            'name': 'test.md',
+            'download_url': 'https://dl.me/page'
+        }])
+        rmock.get('https://dl.me/page', exc=requests.exceptions.ConnectTimeout)
+        menu = get_menu_list('footer')
+        assert len(menu) == 1
+        assert menu[0] == 'dummy_from_cache'

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -88,11 +88,12 @@ nav.Bar(
     [nav.Item(label, label, url=url) for label, url in NETWORK_LINKS]
 )
 
-pages_menu = get_menu_list('footer')
-print('------->', pages_menu)
-nav.Bar(
-    'gouvfr_pages', [nav.Item(pm[0], None, url=pm[1]) for pm in pages_menu]
-)
+# do not attempt to fetch stuff from github when TESTING
+if not current_app.config['TESTING']:
+    pages_menu = get_menu_list('footer')
+    nav.Bar(
+        'gouvfr_pages', [nav.Item(pm[0], None, url=pm[1]) for pm in pages_menu]
+    )
 
 
 @cache.memoize(50)

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -183,7 +183,7 @@ def _discourse_request(url):
         return
 
 
-@cache.cached(50)
+@cache.memoize(50)
 def get_discourse_posts():
     base_url = current_app.config.get('DISCOURSE_URL')
     category_id = current_app.config.get('DISCOURSE_CATEGORY_ID')

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -12,6 +12,8 @@ from udata.app import cache, nav
 from udata.models import Dataset
 from udata.i18n import lazy_gettext as _
 
+from udata_gouvfr.pages.utils import get_menu_list
+
 log = logging.getLogger(__name__)
 
 RE_POST_IMG = re.compile(
@@ -84,6 +86,10 @@ NETWORK_LINKS = [
 nav.Bar(
     'gouvfr_network',
     [nav.Item(label, label, url=url) for label, url in NETWORK_LINKS]
+)
+
+nav.Bar(
+    'gouvfr_pages', get_menu_list('footer')
 )
 
 

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -88,8 +88,10 @@ nav.Bar(
     [nav.Item(label, label, url=url) for label, url in NETWORK_LINKS]
 )
 
+pages_menu = get_menu_list('footer')
+print('------->', pages_menu)
 nav.Bar(
-    'gouvfr_pages', get_menu_list('footer')
+    'gouvfr_pages', [nav.Item(pm[0], None, url=pm[1]) for pm in pages_menu]
 )
 
 

--- a/udata_gouvfr/theme/templates/footer.html
+++ b/udata_gouvfr/theme/templates/footer.html
@@ -21,6 +21,21 @@
                     </li>
                     {% endfor %}
                 </ul>
+                <ul>
+                    <!-- TODO add agressive caching -->
+                    {% for item in nav.gouvfr_pages %}
+                    <li>
+                        <a href="{{ '' if item.items else item.url }}">{{ item.label }}</a>
+                        {% if item.items %}
+                        <ul>
+                            {% for subitem in item.items %}
+                            <li><a href="{{ subitem.url }}">{{ subitem.label }}</a></li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
             </section>
             <section class="col-xs-6 col-sm-3 col-md-2 col-lg-2">
                 <h5>{{ _('Topics') }}</h5>

--- a/udata_gouvfr/theme/templates/footer.html
+++ b/udata_gouvfr/theme/templates/footer.html
@@ -22,7 +22,6 @@
                     {% endfor %}
                 </ul>
                 <ul>
-                    <!-- TODO add agressive caching -->
                     {% for item in nav.gouvfr_pages %}
                     <li>
                         <a href="{{ '' if item.items else item.url }}">{{ item.label }}</a>


### PR DESCRIPTION
Adding the following front matter to a page in https://github.com/etalab/datagouvfr-pages will generate a footer link:

```
menu:
  - footer
```

ATM, the links are added in the "open data" section. There might be a better place for them.

<img width="322" alt="Capture d'écran 2020-06-25 21 39 11" src="https://user-images.githubusercontent.com/119625/85787875-59b99500-b72c-11ea-9a32-1d014bfc954e.png">

TODO:
- [x] agressive ~~template~~ caching — `menu_list` is cached one hour in Redis
- [x] tests
