### PR TITLE
Add footer link to pages summary and page cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add footer link to pages summary and page cache [#488](https://github.com/etalab/udata-gouvfr/pull/488)
 
 ## 2.1.4 (2020-06-29)
 

--- a/udata_gouvfr/tests/test_static_pages.py
+++ b/udata_gouvfr/tests/test_static_pages.py
@@ -1,9 +1,11 @@
 import pytest
+import requests
 
 from flask import url_for
 
+from udata.app import cache
 from udata_gouvfr.views import get_pages_gh_urls
-from .tests import GouvFrSettings
+from udata_gouvfr.tests.tests import GouvFrSettings
 
 
 @pytest.mark.usefixtures('clean_db')
@@ -16,6 +18,39 @@ class StaticPagesTest:
         rmock.get(raw_url, status_code=404)
         response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
         assert response.status_code == 404
+
+    def test_page_error_no_cache(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('doesnotexist')
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        assert response.status_code == 503
+
+    def test_page_timeout_no_cache(self, client, rmock):
+        raw_url, gh_url = get_pages_gh_urls('doesnotexist')
+        rmock.get(raw_url, exc=requests.exceptions.ConnectTimeout)
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        assert response.status_code == 503
+
+    def test_page_error_w_cache(self, client, rmock, mocker):
+        cache_mock_set = mocker.patch.object(cache, 'set')
+        mocker.patch.object(cache, 'get', return_value='dummy_from_cache')
+        raw_url, gh_url = get_pages_gh_urls('cache1')
+        # fill cache
+        rmock.get(raw_url, text="""#test""")
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert cache_mock_set.called
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert response.status_code == 200
+        assert b'dummy_from_cache' in response.data
+        assert rmock.call_count == 2
+
+    def test_page_error_empty_cache(self, client, rmock, mocker):
+        mocker.patch.object(cache, 'get', return_value=None)
+        raw_url, gh_url = get_pages_gh_urls('cache1')
+        rmock.get(raw_url, status_code=500)
+        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        assert response.status_code == 503
 
     def test_page(self, client, rmock):
         raw_url, gh_url = get_pages_gh_urls('test')

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -70,9 +70,8 @@ if export_dataset_id:
                              _external=True)
         footer_links.append(nav.Item(_('Data catalog'), None, url=export_url))
 
-key_data_url = url_for('gouvfr.show_page', slug='donnees-cles-par-sujet',
-                       _external=True)
-footer_links.append(nav.Item('Données clés par sujet', None, url=key_data_url))
+footer_links.append(nav.Item('Données clés par sujet', 'gouvfr.show_page',
+                             args={'slug': 'donnees-cles-par-sujet'}))
 
 nav.Bar('gouvfr_footer', footer_links)
 

--- a/udata_gouvfr/theme/__init__.py
+++ b/udata_gouvfr/theme/__init__.py
@@ -58,6 +58,7 @@ footer_links = [
     nav.Item(_('Terms of use'), 'site.terms'),
     nav.Item(_('Tracking and privacy'), 'gouvfr.suivi'),
 ]
+
 export_dataset_id = current_app.config.get('EXPORT_CSV_DATASET_ID')
 if export_dataset_id:
     try:
@@ -68,6 +69,10 @@ if export_dataset_id:
         export_url = url_for('datasets.show', dataset=export_dataset,
                              _external=True)
         footer_links.append(nav.Item(_('Data catalog'), None, url=export_url))
+
+key_data_url = url_for('gouvfr.show_page', slug='donnees-cles-par-sujet',
+                       _external=True)
+footer_links.append(nav.Item('Données clés par sujet', None, url=key_data_url))
 
 nav.Bar('gouvfr_footer', footer_links)
 
@@ -174,7 +179,7 @@ def _discourse_request(url):
         return
 
 
-@cache.cached(50)
+@cache.memoize(50)
 def get_discourse_posts():
     base_url = current_app.config.get('DISCOURSE_URL')
     category_id = current_app.config.get('DISCOURSE_CATEGORY_ID')


### PR DESCRIPTION
This replaces #486 with a simpler solution: we will maintain a summary page of pages, so we only need one link in the footer and it does not need to be dynamic.

This also embeds the smarter caching for page content from #486.

Close #486.