### PR TITLE
Changed inventory page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Keep tracking to strictly necessary [#517](https://github.com/etalab/udata-gouvfr/pull/517)
+- Changed the title of the elections inventory page [#520](https://github.com/etalab/udata-gouvfr/pull/520)
 
 ## 2.5.1 (2021-01-26)
 

--- a/udata_gouvfr/theme/templates/home.html
+++ b/udata_gouvfr/theme/templates/home.html
@@ -82,7 +82,7 @@
                         <li class="col-sm-4 col-xs-12">
                             <a class="card-link" href="{{ url_for('gouvfr.show_page', slug='donnees-des-elections') }}">
                             <div class="inventory-card blue">
-                                <h4 class="inventory-text">Données des<span class="inventory-title">ÉLECTIONS</span></h4>
+                                <h4 class="inventory-text">Données relatives aux<span class="inventory-title">ÉLECTIONS</span></h4>
                             </div>
                             </a>
                         </li>


### PR DESCRIPTION
Changed the title of the elections inventory page in the homepage from "Données des ÉLECTIONS" to "Données relatives aux ÉLECTIONS", to have a uniform title convention. (merci Antonin)