### PR TITLE
WIP: Use pypi v3 wheel

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
-udata @ https://20680-19141754-gh.circle-artifacts.com/0/dist/udata-3.0.0.dev20680-py2.py3-none-any.whl
+udata>=3.0.0.dev
 feedparser==5.2.1
 python-frontmatter==0.5.0


### PR DESCRIPTION
Use v3.0.0.dev wheel from pypi.

Need to merge opendatateam/udata#2622 for wheel publication on remove-theme.