### PR TITLE
Fix /pages trailing slash + cleanup spd/licences views

### DIFF
--- a/udata_gouvfr/tests/test_static_pages.py
+++ b/udata_gouvfr/tests/test_static_pages.py
@@ -49,20 +49,20 @@ class StaticPagesTest:
 
     def test_page_error_empty_cache(self, client, rmock, mocker):
         mocker.patch.object(cache, 'get', return_value=None)
-        raw_url, gh_url = get_pages_gh_urls('cache1')
+        raw_url, _ = get_pages_gh_urls('cache1')
         rmock.get(raw_url, status_code=500)
         response = client.get(url_for('gouvfr.show_page', slug='cache1'))
         assert response.status_code == 503
 
     def test_page(self, client, rmock):
-        raw_url, gh_url = get_pages_gh_urls('test')
+        raw_url, _ = get_pages_gh_urls('test')
         rmock.get(raw_url, text="""#test""")
         response = client.get(url_for('gouvfr.show_page', slug='test'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
 
     def test_page_inject_empty_objects(self, client, rmock):
-        raw_url, gh_url = get_pages_gh_urls('test')
+        raw_url, _ = get_pages_gh_urls('test')
         rmock.get(raw_url, text=f"""---
 datasets:
 reuses:
@@ -75,7 +75,7 @@ reuses:
     def test_page_inject_objects(self, client, rmock):
         dataset = DatasetFactory()
         reuse = ReuseFactory()
-        raw_url, gh_url = get_pages_gh_urls('test')
+        raw_url, _ = get_pages_gh_urls('test')
         rmock.get(raw_url, text=f"""---
 datasets:
   - {dataset.id}
@@ -88,3 +88,10 @@ reuses:
         assert response.status_code == 200
         assert str(dataset.title).encode('utf-8') in response.data
         assert str(reuse.title).encode('utf-8') in response.data
+
+    def test_page_subdir(self, client, rmock):
+        raw_url, _ = get_pages_gh_urls('subdir/test')
+        rmock.get(raw_url, text="""#test""")
+        response = client.get(url_for('gouvfr.show_page', slug='subdir/test'))
+        assert response.status_code == 200
+        assert b'<h1>test</h1>' in response.data

--- a/udata_gouvfr/tests/tests.py
+++ b/udata_gouvfr/tests/tests.py
@@ -765,28 +765,6 @@ class SpatialTerritoriesApiTest:
         assert response.json['features'] == []
 
 
-class SitemapTest:
-    settings = GouvFrSettings
-    modules = []
-
-    def test_urls_within_sitemap(self, client):
-        '''It should add gouvfr pages to sitemap.'''
-        response = client.get('sitemap.xml')
-        assert200(response)
-
-        urls = [
-            url_for('gouvfr.redevances_redirect', _external=True),
-            url_for('gouvfr.faq_redirect', _external=True),
-        ]
-        for section in ('citizen', 'producer', 'reuser', 'developer',
-                        'system-integrator'):
-            urls.append(url_for('gouvfr.faq_redirect',
-                                section=section, _external=True))
-
-        for url in urls:
-            assert '<loc>{url}</loc>'.format(url=url) in response.data.decode('utf-8')
-
-
 @pytest.mark.usefixtures('clean_db')
 class SitemapTerritoriesTest:
     settings = TerritoriesSettings

--- a/udata_gouvfr/theme/gouvfr/__init__.py
+++ b/udata_gouvfr/theme/gouvfr/__init__.py
@@ -55,10 +55,10 @@ theme.menu(gouvfr_menu)
 footer_links = [
     nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Documentation'), None, url='https://doc.data.gouv.fr'),
-    nav.Item(_('Reference Data'), 'gouvfr.show_page', args={'slug': 'spd'}),
-    nav.Item(_('Licences'), 'gouvfr.show_page', args={'slug': 'licences'}),
+    nav.Item(_('Reference Data'), 'gouvfr.show_page', args={'slug': 'static/reference'}),
+    nav.Item(_('Licences'), 'gouvfr.show_page', args={'slug': 'static/licences'}),
     nav.Item(_('API'), None, url=current_app.config.get('API_DOC_EXTERNAL_LINK', '#')),
-    nav.Item(_('Terms of use'), 'site.terms'),
+    nav.Item(_('Terms of use'), 'gouvfr.show_page', args={'slug': 'static/cgu'}),
     nav.Item(_('Tracking and privacy'), 'gouvfr.suivi'),
 ]
 

--- a/udata_gouvfr/theme/gouvfr/__init__.py
+++ b/udata_gouvfr/theme/gouvfr/__init__.py
@@ -58,7 +58,7 @@ footer_links = [
     nav.Item(_('Reference Data'), 'gouvfr.show_page', args={'slug': 'static/reference'}),
     nav.Item(_('Licences'), 'gouvfr.show_page', args={'slug': 'static/licences'}),
     nav.Item(_('API'), None, url=current_app.config.get('API_DOC_EXTERNAL_LINK', '#')),
-    nav.Item(_('Terms of use'), 'gouvfr.show_page', args={'slug': 'static/cgu'}),
+    nav.Item(_('Terms of use'), 'site.terms'),
     nav.Item(_('Tracking and privacy'), 'gouvfr.suivi'),
 ]
 

--- a/udata_gouvfr/theme/gouvfr/__init__.py
+++ b/udata_gouvfr/theme/gouvfr/__init__.py
@@ -55,8 +55,8 @@ theme.menu(gouvfr_menu)
 footer_links = [
     nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Documentation'), None, url='https://doc.data.gouv.fr'),
-    nav.Item(_('Reference Data'), 'gouvfr.spd'),
-    nav.Item(_('Licences'), 'gouvfr.licences'),
+    nav.Item(_('Reference Data'), 'gouvfr.show_page', args={'slug': 'spd'}),
+    nav.Item(_('Licences'), 'gouvfr.show_page', args={'slug': 'licences'}),
     nav.Item(_('API'), None, url=current_app.config.get('API_DOC_EXTERNAL_LINK', '#')),
     nav.Item(_('Terms of use'), 'site.terms'),
     nav.Item(_('Tracking and privacy'), 'gouvfr.suivi'),

--- a/udata_gouvfr/theme/gouvfr/templates/home.html
+++ b/udata_gouvfr/theme/gouvfr/templates/home.html
@@ -18,7 +18,7 @@
                 <h1 class="mt-0">{{ _('Open platform for French public data') }}</h1>
                 <div class="mt-md mt-lg-sm">
                     <h4>{{ _('Featured topics') }}</h4>
-                    <a href="{{ url_for('gouvfr.spd') }}" class=" btn-venti bg-blue-470">
+                    <a href="{{ url_for('gouvfr.show_page', slug='spd') }}" class=" btn-venti bg-blue-470">
                         Données de
                         <strong>Référence</strong>
                     </a>

--- a/udata_gouvfr/theme/gouvfr/templates/home.html
+++ b/udata_gouvfr/theme/gouvfr/templates/home.html
@@ -18,7 +18,7 @@
                 <h1 class="mt-0">{{ _('Open platform for French public data') }}</h1>
                 <div class="mt-md mt-lg-sm">
                     <h4>{{ _('Featured topics') }}</h4>
-                    <a href="{{ url_for('gouvfr.show_page', slug='spd') }}" class=" btn-venti bg-blue-470">
+                    <a href="{{ url_for('gouvfr.show_page', slug='static/spd') }}" class=" btn-venti bg-blue-470">
                         Données de
                         <strong>Référence</strong>
                     </a>

--- a/udata_gouvfr/views/gouvfr.py
+++ b/udata_gouvfr/views/gouvfr.py
@@ -102,7 +102,7 @@ def get_object(model, id_or_slug):
     return obj
 
 
-@blueprint.route('/pages/<slug>')
+@blueprint.route('/pages/<slug>/')
 def show_page(slug):
     content, gh_url = get_page_content(slug)
     page = frontmatter.loads(content)
@@ -116,33 +116,10 @@ def show_page(slug):
     )
 
 
-@blueprint.route('/reference')
-def spd():
-    datasets = Dataset.objects(badges__kind=SPD).order_by('title')
-    return theme.render('spd.html', datasets=datasets, badge=SPD)
-
-
-@blueprint.route('/licences')
-def licences():
-    try:
-        return theme.render('licences.html')
-    except TemplateNotFound:
-        abort(404)
-
-
-@blueprint.route('/suivi')
+@blueprint.route('/suivi/')
 def suivi():
     try:
         return theme.render('suivi.html')
-    except TemplateNotFound:
-        abort(404)
-
-
-@blueprint.route('/faq/', defaults={'section': 'home'})
-@blueprint.route('/faq/<string:section>/')
-def faq(section):
-    try:
-        return theme.render('faq/{0}.html'.format(section), page_name=section)
     except TemplateNotFound:
         abort(404)
 
@@ -167,7 +144,7 @@ def dataset_apis(ctx):
 
 
 # TODO : better this, redirect is not the best. How to serve it instead ?!
-@blueprint.route('/_stylemark/<path:filename>')
+@blueprint.route('/_stylemark/<path:filename>/')
 def stylemark(filename):
     return redirect(theme_static_with_version(None,
                                               filename="stylemark/index.html"))

--- a/udata_gouvfr/views/gouvfr.py
+++ b/udata_gouvfr/views/gouvfr.py
@@ -99,7 +99,7 @@ def get_object(model, id_or_slug):
     return obj
 
 
-@blueprint.route('/pages/<slug>/')
+@blueprint.route('/pages/<path:slug>/')
 def show_page(slug):
     content, gh_url = get_page_content(slug)
     page = frontmatter.loads(content)

--- a/udata_gouvfr/views/gouvfr.py
+++ b/udata_gouvfr/views/gouvfr.py
@@ -16,8 +16,6 @@ from udata.sitemap import sitemap
 from udata_gouvfr import APIGOUVFR_EXTRAS_KEY
 from udata_gouvfr.frontend import template_hook
 
-from udata_gouvfr.models import SPD
-
 log = logging.getLogger(__name__)
 
 blueprint = I18nBlueprint('gouvfr', __name__,
@@ -122,14 +120,6 @@ def suivi():
         return theme.render('suivi.html')
     except TemplateNotFound:
         abort(404)
-
-
-@sitemap.register_generator
-def gouvfr_sitemap_urls():
-    yield 'gouvfr.faq_redirect', {}, None, 'weekly', 1
-    for section in ('citizen', 'producer', 'reuser', 'developer',
-                    'system-integrator'):
-        yield 'gouvfr.faq_redirect', {'section': section}, None, 'weekly', 0.7
 
 
 def has_apis(ctx):

--- a/udata_gouvfr/views/gouvfr.py
+++ b/udata_gouvfr/views/gouvfr.py
@@ -11,7 +11,6 @@ from udata_gouvfr.theme import theme_static_with_version
 from udata.app import cache
 from udata.models import Reuse, Dataset
 from udata.i18n import I18nBlueprint
-from udata.sitemap import sitemap
 
 from udata_gouvfr import APIGOUVFR_EXTRAS_KEY
 from udata_gouvfr.frontend import template_hook


### PR DESCRIPTION
This PR:
- handles trailing slashes for static pages routing
- handles subdirectories routing for static pages
- cleans up unused views that have been migrated to static pages

Fix https://github.com/etalab/data.gouv.fr/issues/282
Fix https://github.com/etalab/data.gouv.fr/issues/289