### PR TITLE
Changed btn-venti to logement urbanisme

### DIFF
--- a/udata_gouvfr/theme/gouvfr/templates/home.html
+++ b/udata_gouvfr/theme/gouvfr/templates/home.html
@@ -27,10 +27,10 @@
                         Données relatives à la
                         <strong>COVID-19</strong>
                     </a>
-                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-comptes-publics') }}"
+                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-logement-urbanisme') }}"
                         class="btn-venti bg-green-350">
-                        Données relatives aux
-                        <strong>Comptes Publics</strong>
+                        Données relatives au
+                        <strong>Logement et à l'Urbanisme</strong>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Swapped the _comptes publics_ venti button for one to the [new _logement et urbanisme_ page](https://www.data.gouv.fr/fr/pages/donnees-logement-urbanisme). Colour is the same because of the limited palette in theme/less/content/colors.less