### PR TITLE
Set expanded to false for all resources

### DIFF
--- a/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
+++ b/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
@@ -254,7 +254,7 @@
             {% if nb_groups > 1 %}<h4 class="fs-lg mt-xl">{{ type_label }} <sup>{{resources|length }}</sup></h4>
             {% endif %}
             {% for resource in resources[:max_resources] %}
-            {% with expanded = "true" if type == "main" else "false" %}
+            {% with expanded = "false" %}
             {% include theme('dataset/resource/card.html') %}
             {% endwith %}
             {% endfor %}


### PR DESCRIPTION
Fix etalab/data.gouv.fr#326.

No particular treatment for main resources anymore.