### PR TITLE
Fix datasets search pagination reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Fix datasets search pagination reset [#588](https://github.com/etalab/udata-gouvfr/pull/588)
 - Replace link to /search route by /datasets [#587](https://github.com/etalab/udata-gouvfr/pull/587)
 - Removed useless templates, views and tests after v3 [#557](https://github.com/etalab/udata-gouvfr/pull/557)
 - Fix datasets search pagination [#585](https://github.com/etalab/udata-gouvfr/pull/585)

--- a/theme/js/components/search/search.vue
+++ b/theme/js/components/search/search.vue
@@ -228,6 +228,7 @@ export default {
   methods: {
     handleSearchChange(input) {
       this.queryString = input;
+      this.current_page = 1;
       this.search();
     },
     //Called on every facet selector change, updates the `facets.xxx` object then searches with new values
@@ -243,6 +244,7 @@ export default {
           this.facets[facet] = values;
         }
 
+        this.current_page = 1;
         this.search();
       };
     },
@@ -281,6 +283,7 @@ export default {
     resetFilters() {
       this.queryString = "";
       this.facets = {};
+      this.current_page = 1;
       this.search();
     },
   },


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/346

Reset current page on search and suggestor change and on filters reset.