### PR TITLE
Added emploi venti button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix reuses filters issue [#592](https://github.com/etalab/udata-gouvfr/pull/592)
 - Remove suggest on mobile [#590](https://github.com/etalab/udata-gouvfr/pull/590)
+- Added homepage "venti" button for the new inventory [#591](https://github.com/etalab/udata-gouvfr/pull/591)
 
 ## 3.0.1 (2021-07-09)
 

--- a/udata_gouvfr/theme/gouvfr/templates/home.html
+++ b/udata_gouvfr/theme/gouvfr/templates/home.html
@@ -18,14 +18,15 @@
                 <h1 class="mt-0">{{ _('Open platform for French public data') }}</h1>
                 <div class="mt-md mt-lg-sm">
                     <h4>{{ _('Featured topics') }}</h4>
-                    <a href="{{ url_for('gouvfr.show_page', slug='spd/reference') }}" class=" btn-venti bg-blue-470">
-                        Données de
-                        <strong>Référence</strong>
-                    </a>
                     <a href="{{ url_for('gouvfr.show_page', slug='donnees-coronavirus') }}"
-                        class="btn-venti my-md bg-blue-450">
+                        class="btn-venti my-md bg-blue-470">
                         Données relatives à la
                         <strong>COVID-19</strong>
+                    </a>
+                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-emploi') }}"
+                        class="btn-venti my-md bg-blue-450">
+                        Données relatives à
+                        <strong>L'emploi</strong>
                     </a>
                     <a href="{{ url_for('gouvfr.show_page', slug='donnees-logement-urbanisme') }}"
                         class="btn-venti bg-green-350">


### PR DESCRIPTION
Removed the venti button for the SPD and added the button for the new emploi inventory.

Colours have not been changed to stick with the palette https://github.com/etalab/udata-gouvfr/blob/master/theme/less/content/colors.less 

Mockup:
![Capture d’écran 2021-07-09 à 17 50 31](https://user-images.githubusercontent.com/51122275/125104923-3155cc00-e0de-11eb-8b95-72e147cbef9a.jpg)
