### PR TITLE
Fix for reuses filters type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current (in progress)
 
+- Fix reuses filters issue [#592](https://github.com/etalab/udata-gouvfr/pull/592)
 - Remove suggest on mobile [#590](https://github.com/etalab/udata-gouvfr/pull/590)
 
 ## 3.0.1 (2021-07-09)

--- a/udata_gouvfr/theme/gouvfr/templates/reuse/list.html
+++ b/udata_gouvfr/theme/gouvfr/templates/reuse/list.html
@@ -52,7 +52,7 @@
                 class="btn-tab tab {% if not reuses.query._filters.type %}active{% endif %}">{{ _('All') }}</a>
             {% for tab_id, label in reuses_tabs %}
             <a href="{{ reuses.query.to_url(url, replace=True, **{'type': tab_id}) }}"
-                class="btn-tab tab {% if reuses.query._filters and reuses.query._filters.type.type == tab_id %}active{% endif %}">{{ label }}</a>
+                class="btn-tab tab {% if reuses.query._filters and reuses.query._filters.type and reuses.query._filters.type.type == tab_id %}active{% endif %}">{{ label }}</a>
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/336.

Need to make sure that other filters give appropriate results, ex: https://www.data.gouv.fr/en/reuses/?tag=machine-learning&followers=none.