### PR TITLE
Replace mdstrip filter with markdown in resources descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Replace mdstrip filter with markdown in resources descriptions [#606](https://github.com/etalab/udata-gouvfr/pull/606)
 
 ## 3.0.3 (2021-07-30)
 

--- a/udata_gouvfr/theme/gouvfr/templates/dataset/resource/card.html
+++ b/udata_gouvfr/theme/gouvfr/templates/dataset/resource/card.html
@@ -56,9 +56,9 @@
             {% if expanded == 'false' %}style="height: 0px" {% endif %}
             aria-labelledby="resource-{{resource.id}}-header" id="resource-{{resource.id}}">
             {% if resource.description %}
-            <p class="resource-description">
-                {{ resource.description|mdstrip }}
-            </p>
+            <div class="resource-description">
+                {{ resource.description|markdown }}
+            </div>
             {% endif %}
             <dl class="description-list">
                 <div>


### PR DESCRIPTION
fix https://github.com/etalab/data.gouv.fr/issues/437