### PR TITLE
Added santé inventory venti button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Replace mdstrip filter with markdown in resources descriptions [#606](https://github.com/etalab/udata-gouvfr/pull/606)
 - Fix numerous responsive issues and prevent VueJS from crashing the page on compilation error [#605](https://github.com/etalab/udata-gouvfr/pull/605)
+- Replace old COVID-19 inventory button with the new one for santé [#608](https://github.com/etalab/udata-gouvfr/pull/608)
 
 ## 3.0.3 (2021-07-30)
 

--- a/udata_gouvfr/theme/gouvfr/templates/home.html
+++ b/udata_gouvfr/theme/gouvfr/templates/home.html
@@ -18,10 +18,10 @@
                 <h1 class="mt-0 mb-md-md">{{ _('Open platform for French public data') }}</h1>
                 <div class="mt-md mt-lg-sm">
                     <h4>{{ _('Featured topics') }}</h4>
-                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-coronavirus') }}"
+                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-sante') }}"
                         class="btn-venti my-md bg-blue-470">
                         Données relatives à la
-                        <strong>COVID-19</strong>
+                        <strong>Santé et à la COVID-19</strong>
                     </a>
                     <a href="{{ url_for('gouvfr.show_page', slug='donnees-emploi') }}"
                         class="btn-venti my-md bg-blue-450">


### PR DESCRIPTION
Changed the first venti button in the home to link to the new santé inventory https://github.com/etalab/datagouvfr-pages/pull/31

The new santé inventory will have a link to the old COVID-19 inventory

~~Please merge only after publishing the inventory, i.e. when [etalab/datagouvfr-pages/pull/31](https://github.com/etalab/datagouvfr-pages/pull/31) is merged~~ ✅ ok to merge