### PR TITLE
Remove first duplicate participate block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix numerous responsive issues and prevent VueJS from crashing the page on compilation error [#605](https://github.com/etalab/udata-gouvfr/pull/605)
 - Replace old COVID-19 inventory button with the new one for santé [#608](https://github.com/etalab/udata-gouvfr/pull/608)
 - Add SPD datasets to home page [#609](https://github.com/etalab/udata-gouvfr/pull/609)
+- Remove duplicate Participate block on dataset page [#611](https://github.com/etalab/udata-gouvfr/pull/611)
 
 ## 3.0.3 (2021-07-30)
 

--- a/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
+++ b/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
@@ -305,7 +305,6 @@
     </div>
 </section>
 
-{% include theme('participez/participez.html') %}
 {% block community %}
 <section class="community_container bg-grey-400 text-white py-hg" id="community">
     <header>


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/288.

Remove first duplicate block instead of second because community block seems like a footer because of it.