### PR TITLE
Change banner trigger for geo.data.gouv.fr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Change banner trigger for geo.data.gouv.fr [#618](https://github.com/etalab/udata-gouvfr/pull/618)
 
 ## 3.0.5 (2021-08-12)
 

--- a/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
+++ b/udata_gouvfr/theme/gouvfr/templates/dataset/display.html
@@ -64,7 +64,7 @@
     </span>
     {% endif %}
     {# FIXME: remove when geo.data.gouv.fr is shutdown #}
-    {% if 'inspire:identifier' in dataset.extras %}
+    {% if 'geop:dataset_id' in dataset.extras %}
     <div class="well well-orange-200 py-sm mb-lg">
         ⚠️ {{ _("This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> platform.
         This platform is not actively maintained and as a result, you may find some bogus data or metadata.


### PR DESCRIPTION
`geop:dataset_id` is more relevant and specific to geo.data.gouv.fr.