### PR TITLE
Show private datasets and reuses on organization page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update homepage wording [#617](https://github.com/etalab/udata-gouvfr/pull/617)
 - Change banner trigger for geo.data.gouv.fr [#618](https://github.com/etalab/udata-gouvfr/pull/618)
+- Show private datasets and reuses on organization page [#619](https://github.com/etalab/udata-gouvfr/pull/619)
 
 ## 3.0.5 (2021-08-12)
 

--- a/udata_gouvfr/tests/views/test_organization.py
+++ b/udata_gouvfr/tests/views/test_organization.py
@@ -108,11 +108,10 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         rendered_reuses = self.get_context_variable('reuses')
         self.assertEqual(len(rendered_reuses), 0)
 
-        rendered_private_datasets = self.get_context_variable(
-            'private_datasets')
+        rendered_private_datasets = [dataset for dataset in rendered_datasets if dataset.private]
         self.assertEqual(len(rendered_private_datasets), 0)
 
-        rendered_private_reuses = self.get_context_variable('private_reuses')
+        rendered_private_reuses = [reuse for reuse in rendered_reuses if reuse.private]
         self.assertEqual(len(rendered_private_reuses), 0)
 
     def test_render_display_with_private_datasets(self):
@@ -129,12 +128,11 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
 
         self.assert200(response)
         rendered_datasets = self.get_context_variable('datasets')
-        self.assertEqual(len(rendered_datasets), 0)
-
-        rendered_private_datasets = self.get_context_variable(
-            'private_datasets')
-        self.assertEqual(len(rendered_private_datasets),
+        self.assertEqual(len(rendered_datasets),
                          len(datasets) + len(private_datasets))
+
+        rendered_private_datasets = [dataset for dataset in rendered_datasets if dataset.private]
+        self.assertEqual(len(rendered_private_datasets), len(private_datasets))
 
     def test_render_display_with_reuses(self):
         '''It should render the organization page with some reuses'''
@@ -160,11 +158,11 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
 
         self.assert200(response)
         rendered_reuses = self.get_context_variable('reuses')
-        self.assertEqual(len(rendered_reuses), 0)
-
-        rendered_private_reuses = self.get_context_variable('private_reuses')
-        self.assertEqual(len(rendered_private_reuses),
+        self.assertEqual(len(rendered_reuses),
                          len(reuses) + len(private_reuses))
+
+        rendered_private_reuses = [reuse for reuse in rendered_reuses if reuse.private]
+        self.assertEqual(len(rendered_private_reuses), len(private_reuses))
 
     def test_render_display_with_followers(self):
         '''It should render the organization page with followers'''

--- a/udata_gouvfr/tests/views/test_organization.py
+++ b/udata_gouvfr/tests/views/test_organization.py
@@ -91,22 +91,26 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         self.assertEqual(len(rendered_datasets), len(datasets))
 
     def test_render_display_with_private_assets_only_member(self):
-        '''It should render the organization page without private assets'''
+        '''It should render the organization page without private and empty assets'''
         organization = OrganizationFactory()
+        datasets = [VisibleDatasetFactory(organization=organization)
+                    for _ in range(2)]
+        reuses = [VisibleReuseFactory(organization=organization)
+                  for _ in range(2)]
         for _ in range(2):
-            DatasetFactory(organization=organization)
+            DatasetFactory(organization=organization, resources=[])  # Empty asset
             VisibleDatasetFactory(organization=organization, private=True)
-            ReuseFactory(organization=organization)
+            ReuseFactory(organization=organization, datasets=[])  # Empty asset
             VisibleReuseFactory(organization=organization, private=True)
         response = self.get(url_for('organizations.show', org=organization))
 
         self.assert200(response)
 
         rendered_datasets = self.get_context_variable('datasets')
-        self.assertEqual(len(rendered_datasets), 0)
+        self.assertEqual(len(rendered_datasets), len(datasets))
 
         rendered_reuses = self.get_context_variable('reuses')
-        self.assertEqual(len(rendered_reuses), 0)
+        self.assertEqual(len(rendered_reuses), len(reuses))
 
         rendered_private_datasets = [dataset for dataset in rendered_datasets if dataset.private]
         self.assertEqual(len(rendered_private_datasets), 0)
@@ -114,13 +118,21 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         rendered_private_reuses = [reuse for reuse in rendered_reuses if reuse.private]
         self.assertEqual(len(rendered_private_reuses), 0)
 
+        total_datasets = self.get_context_variable('total_datasets')
+        self.assertEqual(total_datasets, len(datasets))
+
+        total_reuses = self.get_context_variable('total_reuses')
+        self.assertEqual(total_reuses, len(reuses))
+
     def test_render_display_with_private_datasets(self):
         '''It should render the organization page with some private datasets'''
         me = self.login()
         member = Member(user=me, role='editor')
         organization = OrganizationFactory(members=[member])
         datasets = [
-            DatasetFactory(organization=organization) for _ in range(2)]
+            VisibleDatasetFactory(organization=organization) for _ in range(2)]
+        empty_datasets = [
+            DatasetFactory(organization=organization, resources=[]) for _ in range(2)]
         private_datasets = [
             VisibleDatasetFactory(organization=organization, private=True)
             for _ in range(2)]
@@ -129,10 +141,14 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         self.assert200(response)
         rendered_datasets = self.get_context_variable('datasets')
         self.assertEqual(len(rendered_datasets),
-                         len(datasets) + len(private_datasets))
+                         len(datasets) + len(private_datasets) + len(empty_datasets))
 
         rendered_private_datasets = [dataset for dataset in rendered_datasets if dataset.private]
         self.assertEqual(len(rendered_private_datasets), len(private_datasets))
+
+        total_datasets = self.get_context_variable('total_datasets')
+        self.assertEqual(total_datasets,
+                         len(datasets) + len(private_datasets) + len(empty_datasets))
 
     def test_render_display_with_reuses(self):
         '''It should render the organization page with some reuses'''
@@ -150,7 +166,9 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         me = self.login()
         member = Member(user=me, role='editor')
         organization = OrganizationFactory(members=[member])
-        reuses = [ReuseFactory(organization=organization) for _ in range(2)]
+        reuses = [VisibleReuseFactory(organization=organization) for _ in range(2)]
+        empty_reuses = [
+            ReuseFactory(organization=organization, datasets=[]) for _ in range(2)]
         private_reuses = [
             VisibleReuseFactory(organization=organization, private=True)
             for _ in range(2)]
@@ -159,10 +177,13 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
         self.assert200(response)
         rendered_reuses = self.get_context_variable('reuses')
         self.assertEqual(len(rendered_reuses),
-                         len(reuses) + len(private_reuses))
+                         len(reuses) + len(private_reuses) + len(empty_reuses))
 
         rendered_private_reuses = [reuse for reuse in rendered_reuses if reuse.private]
         self.assertEqual(len(rendered_private_reuses), len(private_reuses))
+
+        total_reuses = self.get_context_variable('total_reuses')
+        self.assertEqual(total_reuses, len(reuses) + len(private_reuses) + len(empty_reuses))
 
     def test_render_display_with_followers(self):
         '''It should render the organization page with followers'''

--- a/udata_gouvfr/theme/gouvfr/templates/dataset/search-result.html
+++ b/udata_gouvfr/theme/gouvfr/templates/dataset/search-result.html
@@ -25,7 +25,7 @@
     {% endif %}
     <div class="card-data">
         <h4 class="card-title">{{ dataset.full_title }}
-            {% if dataset.private %}<span class="badge grey-300 ml-xs">Privé</span>{% endif %}</h4>
+            {% if dataset.private %}<span class="badge grey-300 ml-xs">{{ _('Private') }}</span>{% endif %}</h4>
         <div class="card-description text-grey-300 mt-xs">
             {{ dataset.description|mdstrip(300) }}
         </div>

--- a/udata_gouvfr/theme/gouvfr/templates/reuse/card.html
+++ b/udata_gouvfr/theme/gouvfr/templates/reuse/card.html
@@ -23,6 +23,7 @@
             </div>
             <div class="reuse-info-title h4">
                 {{ reuse.title }}
+                {% if reuse.private %}<span class="badge grey-300 ml-xs">{{ _('Private') }}</span>{% endif %}
             </div>
         </div>
     </article>

--- a/udata_gouvfr/views/organization.py
+++ b/udata_gouvfr/views/organization.py
@@ -78,32 +78,27 @@ class OrganizationDetailView(OrgView, DetailView):
 
         datasets = Dataset.objects(
             organization=self.organization).order_by(
-            '-temporal_coverage.end', '-metrics.reuses', '-metrics.followers').visible()
+            '-temporal_coverage.end', '-metrics.reuses', '-metrics.followers')
 
         reuses = Reuse.objects(
             organization=self.organization).order_by(
-            '-metrics.reuses', '-metrics.followers').visible()
+            '-metrics.reuses', '-metrics.followers')
 
         followers = (Follow.objects.followers(self.organization)
                      .order_by('follower.fullname'))
 
-        private_reuses = list(Reuse.objects(organization=self.object).hidden()) if can_view else []
-        private_datasets = list(Dataset.objects(
-            organization=self.object).hidden()) if can_view else []
-
-        total_datasets = len(datasets) + len(private_datasets)
-        total_reuses = len(reuses) + len(private_reuses)
+        if not can_view:
+            datasets = datasets.visible()
+            reuses = reuses.visible()
 
         context.update({
             'reuses': reuses.paginate(params_reuses_page, self.page_size),
             'datasets': datasets.paginate(params_datasets_page, self.page_size),
-            'total_datasets': total_datasets,
-            'total_reuses': total_reuses,
+            'total_datasets': len(datasets),
+            'total_reuses': len(reuses),
             'followers': followers,
             'can_edit': can_edit,
             'can_view': can_view,
-            'private_reuses': private_reuses,
-            'private_datasets': private_datasets,
         })
         return context
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/421 and https://github.com/etalab/data.gouv.fr/issues/420.

Show hidden datasets and reuses in same block as public ones.
For private datasets, a badge is shown.

Fix tests accordingly (and make empty assets explicit in those).

Ex: 
![image](https://user-images.githubusercontent.com/28541902/129362016-d2b0d859-a74e-4baa-a263-4556563c4313.png)
