### PR TITLE
Make banner configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update homepage wording [#617](https://github.com/etalab/udata-gouvfr/pull/617)
 - Change banner trigger for geo.data.gouv.fr [#618](https://github.com/etalab/udata-gouvfr/pull/618)
 - Show private datasets and reuses on organization page [#619](https://github.com/etalab/udata-gouvfr/pull/619)
+- Make frontend banner configurable [#621](https://github.com/etalab/udata-gouvfr/pull/621)
 
 ## 3.0.5 (2021-08-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Update homepage wording [#617](https://github.com/etalab/udata-gouvfr/pull/617)
 - Change banner trigger for geo.data.gouv.fr [#618](https://github.com/etalab/udata-gouvfr/pull/618)
 - Show private datasets and reuses on organization page [#619](https://github.com/etalab/udata-gouvfr/pull/619)
-- Make frontend banner configurable [#621](https://github.com/etalab/udata-gouvfr/pull/621)
+- Make frontend banner configurable and remove newsletter banner settings [#621](https://github.com/etalab/udata-gouvfr/pull/621)
 
 ## 3.0.5 (2021-08-12)
 

--- a/udata_gouvfr/settings.py
+++ b/udata_gouvfr/settings.py
@@ -9,8 +9,8 @@ SCHEMA_CATALOG_URL = 'https://schema.data.gouv.fr/schemas/schemas.json'
 
 # Frontend banner parameters
 BANNER_ACTIVATED = False
-EN_BANNER_HTML_CONTENT = ''
-FR_BANNER_HTML_CONTENT = ''
+BANNER_HTML_CONTENT_EN = ''
+BANNER_HTML_CONTENT_FR = ''
 
 # Static pages from github repo
 PAGES_GH_REPO_NAME = 'etalab/datagouvfr-pages'

--- a/udata_gouvfr/settings.py
+++ b/udata_gouvfr/settings.py
@@ -19,9 +19,3 @@ PAGES_REPO_BRANCH = 'master'
 # api.gouv.fr
 APIGOUVFR_URL = 'https://api.gouv.fr/api/v1/apis'
 APIGOUVFR_ALLOW_OPENNESS = ['open', 'semi_open']
-
-# Newsletter's subscription page's link
-POST_BANNER_ACTIVATED = True
-POST_BANNER_LINK = 'https://infolettres.etalab.gouv.fr/subscribe/rn7y93le1'
-POST_BANNER_MESSAGE = 'Pour ne rien manquer, de l’actualité de data.gouv.fr'\
-                      'et de l’open data, inscrivez-vous à notre infolettre.'

--- a/udata_gouvfr/settings.py
+++ b/udata_gouvfr/settings.py
@@ -9,7 +9,8 @@ SCHEMA_CATALOG_URL = 'https://schema.data.gouv.fr/schemas/schemas.json'
 
 # Frontend banner parameters
 BANNER_ACTIVATED = False
-BANNER_HTML_CONTENT = ''
+EN_BANNER_HTML_CONTENT = ''
+FR_BANNER_HTML_CONTENT = ''
 
 # Static pages from github repo
 PAGES_GH_REPO_NAME = 'etalab/datagouvfr-pages'

--- a/udata_gouvfr/tests/views/test_site.py
+++ b/udata_gouvfr/tests/views/test_site.py
@@ -48,6 +48,27 @@ class SiteViewsTest(GouvfrFrontTestCase):
         response = self.get(url_for('site.home'))
         self.assert200(response)
 
+    @pytest.mark.options(BANNER_ACTIVATED=False)
+    @pytest.mark.options(BANNER_HTML_CONTENT_EN='BANNER_TEST')
+    def test_render_home_no_banner(self):
+        '''It should render the home page without banner'''
+        response = self.get(url_for('site.home'))
+        self.assert200(response)
+        self.assertNotIn(b"BANNER_TEST", response.data)
+
+    @pytest.mark.options(BANNER_ACTIVATED=True)
+    @pytest.mark.options(BANNER_HTML_CONTENT_EN='BANNER_TEST_EN')
+    @pytest.mark.options(BANNER_HTML_CONTENT_FR='BANNER_TEST_FR')
+    def test_render_home_with_banner(self):
+        '''It should render the home page with a banner'''
+        response = self.get(url_for('site.home', lang_code='en'))
+        self.assert200(response)
+        self.assertIn(b"BANNER_TEST_EN", response.data)
+
+        response = self.get(url_for('site.home', lang_code='fr'))
+        self.assert200(response)
+        self.assertIn(b"BANNER_TEST_FR", response.data)
+
     def test_render_dashboard(self):
         '''It should render the search page'''
         for i in range(3):

--- a/udata_gouvfr/theme/gouvfr/templates/banners/generic.html
+++ b/udata_gouvfr/theme/gouvfr/templates/banners/generic.html
@@ -1,7 +1,9 @@
-<nav class="navbar navbar-static-top navbar-banner">
-    <div class="container banner">
-        <p class="text-center text-white">
-            {{ b_content|safe }}
-        </p>
+<div class="bg-blue-350 banner">
+    <div class="hagrid">
+        <div class="inline-row align-items-center text-align-center-sm">
+            <p class="text-white">
+                {{ banner_message|safe }}
+            </p>
+        </div>
     </div>
-</nav>
+</div>

--- a/udata_gouvfr/theme/gouvfr/templates/header.html
+++ b/udata_gouvfr/theme/gouvfr/templates/header.html
@@ -1,16 +1,10 @@
-<div class="bg-blue-350 banner">
-    <div class="hagrid">
-        <div class="inline-row align-items-center text-align-center-sm">
-            <p class="text-white">
-                {{ _("Welcome to the new <i>beta</i> version of data.gouv.fr! <a href='{learn_more}'>Learn more</a>, go back to <a href='{legacy}'>the old version</a> or <a href='{feedback}'>send us some feedback</a>.").format(
-                    learn_more='https://www.data.gouv.fr/fr/posts/nouvelle-vie-nouvelle-peau-pour-data-gouv-fr/' if g.lang_code == 'fr' else 'https://www.data.gouv.fr/{lang}/posts/en-data-gouv-fr-graphic-redesign/'.format(lang=g.lang_code),
-                    legacy='https://legacy.data.gouv.fr',
-                    feedback='https://support.data.gouv.fr/particulier/retour-plateforme',
-                ) }}
-            </p>
-        </div>
-    </div>
-</div>
+{% set banner_activated = config['BANNER_ACTIVATED'] %}
+{% if banner_activated %}
+{% block banner %}
+    {% set banner_message = config['FR_BANNER_MESSAGE'] if g.lang_code == "fr" else config['EN_BANNER_MESSAGE'] %}
+    {% include theme('banners/generic.html') with context %}
+{% endblock %}
+{% endif %}
 
 <section class="site-header" ref="header">
     <!--[if lte IE 8]>

--- a/udata_gouvfr/theme/gouvfr/templates/header.html
+++ b/udata_gouvfr/theme/gouvfr/templates/header.html
@@ -1,7 +1,7 @@
 {% set banner_activated = config['BANNER_ACTIVATED'] %}
 {% if banner_activated %}
 {% block banner %}
-    {% set banner_message = config['FR_BANNER_MESSAGE'] if g.lang_code == "fr" else config['EN_BANNER_MESSAGE'] %}
+    {% set banner_message = config['BANNER_HTML_CONTENT_FR'] if g.lang_code == "fr" else config['BANNER_HTML_CONTENT_EN'] %}
     {% include theme('banners/generic.html') with context %}
 {% endblock %}
 {% endif %}


### PR DESCRIPTION
Make banner configurable (as previously existed with `BANNER_HTML_CONTENT` setting pre-refonte).

Questions:
- should we remove the subscription settings (`POST_BANNER_XXX` settings), currently unused ?
- won't the current content be too huge for a single setting and should we make it modular ? Not sure we can make something generic though.

We'll need to update the different playbooks accordingly (demo.data.gouv.fr is currently using the unused `BANNER_HTML_CONTENT`).