### PR TITLE
Don't commit deps changes in case of a tag build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ jobs:
       - run:
           name: Commit any change in compiled *.pip
           command: |
+            echo "here is the git diff after dependencies update:"
+            git diff
             if [[ $CIRCLE_TAG ]]; then
               echo "This a tag build, do not push changes"
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,17 @@ jobs:
       - run:
           name: Commit any change in compiled *.pip
           command: |
-            git config --global user.email "robot@data.gouv.fr"
-            git config --global user.name "Circle CI"
-            ( \
-              git ls-files -m|grep -E "(install|test|develop|udata).pip" \
-              && git commit requirements/*.pip -m "[auto] update deps" \
-              && git push origin ${CIRCLE_BRANCH} \
-            ) || true
+            if [[ $CIRCLE_TAG ]]; then
+              echo "This a tag build, do not push changes"
+            else
+              git config --global user.email "robot@data.gouv.fr"
+              git config --global user.name "Circle CI"
+              ( \
+                git ls-files -m|grep -E "(install|test|develop|udata).pip" \
+                && git commit requirements/*.pip -m "[auto] update deps" \
+                && git push origin ${CIRCLE_BRANCH} \
+              ) || true
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add About in header [#623](https://github.com/etalab/udata-gouvfr/pull/623)
 - Add link to profile in admin for sysadmin [#624](https://github.com/etalab/udata-gouvfr/pull/624)
-- Use pip-tools for dependency management [#626](https://github.com/etalab/udata-gouvfr/pull/626)
+- Use pip-tools for dependency management [#626](https://github.com/etalab/udata-gouvfr/pull/626)[#631](https://github.com/etalab/udata-gouvfr/pull/631)
 
 ## 3.0.7 (2021-08-17)
 


### PR DESCRIPTION
Iterates on https://github.com/etalab/udata-gouvfr/pull/626.

When releasing, circle shouldn't try to push changes to .pip files (fixing `udata==x.x.x` for example)